### PR TITLE
fix(generate): 5 codegen bugs from reference library cross-ref (closes #52, #53)

### DIFF
--- a/generate/analyze.go
+++ b/generate/analyze.go
@@ -92,6 +92,8 @@ func Analyze(dir, filename string) ([]StructInfo, error) {
 		return nil, fmt.Errorf("file %s not found in package", filename)
 	}
 
+	resolvingTypes = make(map[string]bool)
+
 	var infos []StructInfo
 
 	for _, decl := range targetFile.Decls {
@@ -241,8 +243,16 @@ func extractTomlTag(raw string) (string, tagOpts) {
 var primitiveTypes = map[string]bool{
 	"string":  true,
 	"int":     true,
+	"int8":    true,
+	"int16":   true,
+	"int32":   true,
 	"int64":   true,
+	"uint":    true,
+	"uint8":   true,
+	"uint16":  true,
+	"uint32":  true,
 	"uint64":  true,
+	"float32": true,
 	"float64": true,
 	"bool":    true,
 }
@@ -358,6 +368,12 @@ func classifyField(pkg *packages.Package, goName, tomlKey string, expr ast.Expr)
 		case *ast.StarExpr:
 			switch inner := elem.X.(type) {
 			case *ast.Ident:
+				if primitiveTypes[inner.Name] {
+					fi.Kind = FieldSlicePrimitive
+					fi.ElemType = inner.Name
+					fi.SlicePointer = true
+					return fi, nil
+				}
 				fi.Kind = FieldSliceStruct
 				fi.TypeName = inner.Name
 				fi.SlicePointer = true
@@ -482,6 +498,22 @@ func classifyField(pkg *packages.Package, goName, tomlKey string, expr ast.Expr)
 				fi.InnerInfo = &innerInfo
 			}
 			return fi, nil
+		case *ast.StarExpr:
+			// map[string]*Struct
+			switch inner := val.X.(type) {
+			case *ast.Ident:
+				fi.Kind = FieldMapStringStruct
+				fi.TypeName = inner.Name
+				fi.SlicePointer = true
+				innerInfo, err := resolveStructByName(pkg, inner.Name)
+				if err != nil {
+					return fi, err
+				}
+				fi.InnerInfo = &innerInfo
+				return fi, nil
+			default:
+				return fi, fmt.Errorf("unsupported map pointer value type")
+			}
 		default:
 			return fi, fmt.Errorf("unsupported map value type")
 		}
@@ -1055,7 +1087,17 @@ func isMapStringString(m *types.Map) bool {
 	return ok && val.Kind() == types.String
 }
 
+// resolvingTypes tracks which struct types are currently being resolved
+// to detect recursive type references. Reset at the start of each Analyze call.
+var resolvingTypes map[string]bool
+
 func resolveStructByName(pkg *packages.Package, name string) (StructInfo, error) {
+	if resolvingTypes[name] {
+		return StructInfo{}, fmt.Errorf("recursive struct type %s", name)
+	}
+	resolvingTypes[name] = true
+	defer delete(resolvingTypes, name)
+
 	for _, file := range pkg.Syntax {
 		for _, decl := range file.Decls {
 			genDecl, ok := decl.(*ast.GenDecl)

--- a/generate/analyze_test.go
+++ b/generate/analyze_test.go
@@ -1123,3 +1123,150 @@ type Config struct {
 		t.Errorf("expected field toml key 'filter', got %q", infos[0].Fields[0].TomlKey)
 	}
 }
+
+func TestAnalyzeSelfReferentialStructReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "go.mod", "module example.com/test\n\ngo 1.25.6\n")
+	writeFixture(t, dir, "config.go", `package test
+
+//go:generate tommy generate
+type Node struct {
+	Name  string `+"`"+`toml:"name"`+"`"+`
+	Child *Node  `+"`"+`toml:"child"`+"`"+`
+}
+`)
+
+	_, err := Analyze(dir, "config.go")
+	if err == nil {
+		t.Fatal("expected error for self-referential struct, got nil")
+	}
+	if !strings.Contains(err.Error(), "recursive") {
+		t.Fatalf("expected error mentioning 'recursive', got: %v", err)
+	}
+}
+
+func TestAnalyzeSizedIntegers(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "go.mod", "module example.com/test\n\ngo 1.25.6\n")
+	writeFixture(t, dir, "config.go", `package test
+
+//go:generate tommy generate
+type Config struct {
+	A int8   `+"`"+`toml:"a"`+"`"+`
+	B int16  `+"`"+`toml:"b"`+"`"+`
+	C int32  `+"`"+`toml:"c"`+"`"+`
+	D uint   `+"`"+`toml:"d"`+"`"+`
+	E uint8  `+"`"+`toml:"e"`+"`"+`
+	F uint16 `+"`"+`toml:"f"`+"`"+`
+	G uint32 `+"`"+`toml:"g"`+"`"+`
+	H float32 `+"`"+`toml:"h"`+"`"+`
+}
+`)
+
+	infos, err := Analyze(dir, "config.go")
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 struct, got %d", len(infos))
+	}
+	for _, f := range infos[0].Fields {
+		if f.Kind != FieldPrimitive {
+			t.Errorf("field %s: expected FieldPrimitive, got %v", f.GoName, f.Kind)
+		}
+	}
+}
+
+func TestAnalyzeSlicePointerPrimitive(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "go.mod", "module example.com/test\n\ngo 1.25.6\n")
+	writeFixture(t, dir, "config.go", `package test
+
+//go:generate tommy generate
+type Config struct {
+	Names []*string `+"`"+`toml:"names"`+"`"+`
+	Ports []*int    `+"`"+`toml:"ports"`+"`"+`
+}
+`)
+
+	infos, err := Analyze(dir, "config.go")
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 struct, got %d", len(infos))
+	}
+	for _, f := range infos[0].Fields {
+		if f.Kind != FieldSlicePrimitive {
+			t.Errorf("field %s: expected FieldSlicePrimitive, got %v", f.GoName, f.Kind)
+		}
+		if !f.SlicePointer {
+			t.Errorf("field %s: expected SlicePointer=true", f.GoName)
+		}
+	}
+}
+
+func TestAnalyzeMapStringPointerStruct(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "go.mod", "module example.com/test\n\ngo 1.25.6\n")
+	writeFixture(t, dir, "config.go", `package test
+
+//go:generate tommy generate
+type Config struct {
+	Servers map[string]*Server `+"`"+`toml:"servers"`+"`"+`
+}
+
+type Server struct {
+	Name string `+"`"+`toml:"name"`+"`"+`
+	Port int    `+"`"+`toml:"port"`+"`"+`
+}
+`)
+
+	infos, err := Analyze(dir, "config.go")
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 struct, got %d", len(infos))
+	}
+	f := infos[0].Fields[0]
+	if f.Kind != FieldMapStringStruct {
+		t.Fatalf("expected FieldMapStringStruct, got %v", f.Kind)
+	}
+	if !f.SlicePointer {
+		t.Fatal("expected SlicePointer=true for map[string]*Struct")
+	}
+	if f.InnerInfo == nil {
+		t.Fatal("expected InnerInfo to be set")
+	}
+}
+
+func TestAnalyzePointerPrimitivesAllTypes(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "go.mod", "module example.com/test\n\ngo 1.25.6\n")
+	writeFixture(t, dir, "config.go", `package test
+
+//go:generate tommy generate
+type Config struct {
+	A *string  `+"`"+`toml:"a"`+"`"+`
+	B *int     `+"`"+`toml:"b"`+"`"+`
+	C *int64   `+"`"+`toml:"c"`+"`"+`
+	D *float64 `+"`"+`toml:"d"`+"`"+`
+	E *bool    `+"`"+`toml:"e"`+"`"+`
+	F *uint64  `+"`"+`toml:"f"`+"`"+`
+}
+`)
+
+	infos, err := Analyze(dir, "config.go")
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 struct, got %d", len(infos))
+	}
+	for _, f := range infos[0].Fields {
+		if f.Kind != FieldPointerPrimitive {
+			t.Errorf("field %s: expected FieldPointerPrimitive, got %v", f.GoName, f.Kind)
+		}
+	}
+}

--- a/generate/emit.go
+++ b/generate/emit.go
@@ -318,7 +318,12 @@ func emitDecodeField(fi FieldInfo, dataPath, docVar, containerExpr, keyPrefix st
 	case FieldSlicePrimitive:
 		fmt.Fprintf(&buf, "\tif v, err := document.GetFromContainer[[]%s](%s, %s, %q); err == nil {\n",
 			fi.ElemType, docVar, containerExpr, fi.TomlKey)
-		if fi.TypeName != "" {
+		if fi.SlicePointer {
+			fmt.Fprintf(&buf, "\t\t%s = make([]*%s, len(v))\n", target, fi.ElemType)
+			fmt.Fprintf(&buf, "\t\tfor i := range v {\n")
+			fmt.Fprintf(&buf, "\t\t\t%s[i] = &v[i]\n", target)
+			fmt.Fprintf(&buf, "\t\t}\n")
+		} else if fi.TypeName != "" {
 			fmt.Fprintf(&buf, "\t\t%s = %s(v)\n", target, fi.TypeName)
 		} else {
 			fmt.Fprintf(&buf, "\t\t%s = v\n", target)
@@ -402,7 +407,11 @@ func emitDecodeField(fi FieldInfo, dataPath, docVar, containerExpr, keyPrefix st
 			}
 			fmt.Fprintf(&buf, "\t\tif len(subTables) > 0 {\n")
 			fmt.Fprintf(&buf, "\t\t\td.consumed[%q] = true\n", consumedKey)
-			fmt.Fprintf(&buf, "\t\t\t%s = make(map[string]%s)\n", target, fi.TypeName)
+			if fi.SlicePointer {
+				fmt.Fprintf(&buf, "\t\t\t%s = make(map[string]*%s)\n", target, fi.TypeName)
+			} else {
+				fmt.Fprintf(&buf, "\t\t\t%s = make(map[string]%s)\n", target, fi.TypeName)
+			}
 			fmt.Fprintf(&buf, "\t\t\tfor _, subTable := range subTables {\n")
 			if containerExpr == "d.cstDoc.Root()" {
 				fmt.Fprintf(&buf, "\t\t\t\tmapKey := document.SubTableKey(subTable, %q)\n", fi.TomlKey)
@@ -415,7 +424,11 @@ func emitDecodeField(fi FieldInfo, dataPath, docVar, containerExpr, keyPrefix st
 				code := emitDecodeField(inner, "entry", docVar, "subTable", consumedKey+".\" + mapKey + \".")
 				buf.WriteString("\t\t\t" + code)
 			}
-			fmt.Fprintf(&buf, "\t\t\t\t%s[mapKey] = entry\n", target)
+			if fi.SlicePointer {
+				fmt.Fprintf(&buf, "\t\t\t\t%s[mapKey] = &entry\n", target)
+			} else {
+				fmt.Fprintf(&buf, "\t\t\t\t%s[mapKey] = entry\n", target)
+			}
 			fmt.Fprintf(&buf, "\t\t\t}\n")
 			fmt.Fprintf(&buf, "\t\t}\n")
 			fmt.Fprintf(&buf, "\t}\n")
@@ -668,13 +681,23 @@ func emitEncodeField(fi FieldInfo, dataPath, docVar, containerExpr, keyPrefix st
 	case FieldStruct:
 		if fi.InnerInfo != nil {
 			innerKeyPrefix := keyPrefix + fi.TomlKey + "."
+			needsTableNode := innerFieldsNeedContainer(fi.InnerInfo.Fields)
 			if containerExpr == "d.cstDoc.Root()" {
 				fmt.Fprintf(&buf, "\t{\n")
-				fmt.Fprintf(&buf, "\t\ttableNode := %s.EnsureTable(%q)\n", docVar, fi.TomlKey)
+				if needsTableNode {
+					fmt.Fprintf(&buf, "\t\ttableNode := %s.EnsureTable(%q)\n", docVar, fi.TomlKey)
+				} else {
+					fmt.Fprintf(&buf, "\t\t_ = %s.EnsureTable(%q)\n", docVar, fi.TomlKey)
+				}
 			} else {
 				fmt.Fprintf(&buf, "\t{\n")
-				fmt.Fprintf(&buf, "\t\ttableNode := %s.EnsureTableInContainer(%s, %q)\n",
-					docVar, containerExpr, fi.TomlKey)
+				if needsTableNode {
+					fmt.Fprintf(&buf, "\t\ttableNode := %s.EnsureTableInContainer(%s, %q)\n",
+						docVar, containerExpr, fi.TomlKey)
+				} else {
+					fmt.Fprintf(&buf, "\t\t_ = %s.EnsureTableInContainer(%s, %q)\n",
+						docVar, containerExpr, fi.TomlKey)
+				}
 			}
 			for _, inner := range fi.InnerInfo.Fields {
 				code := emitEncodeField(inner, source, docVar, "tableNode", innerKeyPrefix)
@@ -687,8 +710,14 @@ func emitEncodeField(fi FieldInfo, dataPath, docVar, containerExpr, keyPrefix st
 		if fi.InnerInfo != nil {
 			innerKeyPrefix := keyPrefix + fi.TomlKey + "."
 			fmt.Fprintf(&buf, "\tif %s != nil {\n", source)
-			fmt.Fprintf(&buf, "\t\ttableNode := %s.EnsureTableInContainer(%s, %q)\n",
-				docVar, containerExpr, fi.TomlKey)
+			needsTableNode := innerFieldsNeedContainer(fi.InnerInfo.Fields)
+			if needsTableNode {
+				fmt.Fprintf(&buf, "\t\ttableNode := %s.EnsureTableInContainer(%s, %q)\n",
+					docVar, containerExpr, fi.TomlKey)
+			} else {
+				fmt.Fprintf(&buf, "\t\t_ = %s.EnsureTableInContainer(%s, %q)\n",
+					docVar, containerExpr, fi.TomlKey)
+			}
 			for _, inner := range fi.InnerInfo.Fields {
 				code := emitEncodeField(inner, source, docVar, "tableNode", innerKeyPrefix)
 				buf.WriteString("\t" + code)
@@ -759,7 +788,16 @@ func emitEncodeField(fi FieldInfo, dataPath, docVar, containerExpr, keyPrefix st
 				source, docVar, containerExpr, fi.TomlKey)
 		}
 		encodeSource := source
-		if fi.TypeName != "" {
+		if fi.SlicePointer {
+			tmpVar := "tmp" + fi.GoName
+			fmt.Fprintf(&buf, "\t%s := make([]%s, 0, len(%s))\n", tmpVar, fi.ElemType, source)
+			fmt.Fprintf(&buf, "\tfor _, p := range %s {\n", source)
+			fmt.Fprintf(&buf, "\t\tif p != nil {\n")
+			fmt.Fprintf(&buf, "\t\t\t%s = append(%s, *p)\n", tmpVar, tmpVar)
+			fmt.Fprintf(&buf, "\t\t}\n")
+			fmt.Fprintf(&buf, "\t}\n")
+			encodeSource = tmpVar
+		} else if fi.TypeName != "" {
 			encodeSource = "[]" + fi.ElemType + "(" + source + ")"
 		}
 		fmt.Fprintf(&buf, "\tif err := %s.SetInContainer(%s, %q, %s); err != nil {\n",
@@ -790,9 +828,19 @@ func emitEncodeField(fi FieldInfo, dataPath, docVar, containerExpr, keyPrefix st
 			} else {
 				fmt.Fprintf(&buf, "\t\t\tsubTable := %s.EnsureSubTableInContainer(%s, %q, mapKey)\n", docVar, containerExpr, fi.TomlKey)
 			}
-			for _, inner := range fi.InnerInfo.Fields {
-				code := emitEncodeField(inner, "mapVal", docVar, "subTable", "")
-				buf.WriteString("\t\t" + code)
+			if fi.SlicePointer {
+				fmt.Fprintf(&buf, "\t\t\tif mapVal == nil {\n")
+				fmt.Fprintf(&buf, "\t\t\t\tcontinue\n")
+				fmt.Fprintf(&buf, "\t\t\t}\n")
+				for _, inner := range fi.InnerInfo.Fields {
+					code := emitEncodeField(inner, "(*mapVal)", docVar, "subTable", "")
+					buf.WriteString("\t\t" + code)
+				}
+			} else {
+				for _, inner := range fi.InnerInfo.Fields {
+					code := emitEncodeField(inner, "mapVal", docVar, "subTable", "")
+					buf.WriteString("\t\t" + code)
+				}
 			}
 			fmt.Fprintf(&buf, "\t\t}\n")
 			fmt.Fprintf(&buf, "\t}\n")
@@ -878,15 +926,30 @@ func zeroLiteral(typeName string) string {
 	switch typeName {
 	case "bool":
 		return "false"
-	case "int", "int64", "uint64":
+	case "int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64":
 		return "0"
-	case "float64":
+	case "float32", "float64":
 		return "0.0"
 	case "string":
 		return `""`
 	default:
 		return `""`
 	}
+}
+
+func innerFieldsNeedContainer(fields []FieldInfo) bool {
+	for _, f := range fields {
+		switch f.Kind {
+		case FieldSliceStruct, FieldSliceDelegatedStruct:
+			// These use FindArrayTableNodes/AppendArrayTableEntry by full key,
+			// not the container variable.
+			continue
+		default:
+			return true
+		}
+	}
+	return false
 }
 
 func toLowerFirst(s string) string {

--- a/generate/integration_test.go
+++ b/generate/integration_test.go
@@ -133,6 +133,435 @@ func TestDecodeEncode(t *testing.T) {
 	}
 }
 
+func TestIntegrationSizedIntegers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	dir := t.TempDir()
+
+	repoRoot, err := filepath.Abs(filepath.Join("..", "."))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeFixture(t, dir, "go.mod", strings.Join([]string{
+		"module example.com/sizedints",
+		"",
+		"go 1.26",
+		"",
+		"require github.com/amarbel-llc/tommy v0.0.0",
+		"",
+		"replace github.com/amarbel-llc/tommy => " + repoRoot,
+		"",
+	}, "\n"))
+
+	writeFixture(t, dir, "config.go", `package sizedints
+
+//go:generate tommy generate
+type Config struct {
+	A int8    `+"`"+`toml:"a"`+"`"+`
+	B int16   `+"`"+`toml:"b"`+"`"+`
+	C int32   `+"`"+`toml:"c"`+"`"+`
+	D uint    `+"`"+`toml:"d"`+"`"+`
+	E uint8   `+"`"+`toml:"e"`+"`"+`
+	F uint16  `+"`"+`toml:"f"`+"`"+`
+	G uint32  `+"`"+`toml:"g"`+"`"+`
+	H float32 `+"`"+`toml:"h"`+"`"+`
+}
+`)
+
+	if err := Generate(dir, "config.go"); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	writeFixture(t, dir, "sizedints_test.go", `package sizedints
+
+import "testing"
+
+func TestSizedIntRoundTrip(t *testing.T) {
+	input := []byte(`+"`"+`a = 42
+b = 1000
+c = 100000
+d = 99
+e = 200
+f = 50000
+g = 3000000
+h = 3.14
+`+"`"+`)
+
+	doc, err := DecodeConfig(input)
+	if err != nil {
+		t.Fatalf("DecodeConfig: %v", err)
+	}
+	d := doc.Data()
+	if d.A != 42 {
+		t.Fatalf("A = %d, want 42", d.A)
+	}
+	if d.B != 1000 {
+		t.Fatalf("B = %d, want 1000", d.B)
+	}
+	if d.C != 100000 {
+		t.Fatalf("C = %d, want 100000", d.C)
+	}
+	if d.D != 99 {
+		t.Fatalf("D = %d, want 99", d.D)
+	}
+	if d.E != 200 {
+		t.Fatalf("E = %d, want 200", d.E)
+	}
+	if d.F != 50000 {
+		t.Fatalf("F = %d, want 50000", d.F)
+	}
+	if d.G != 3000000 {
+		t.Fatalf("G = %d, want 3000000", d.G)
+	}
+	if d.H < 3.13 || d.H > 3.15 {
+		t.Fatalf("H = %f, want ~3.14", d.H)
+	}
+
+	// Modify and re-encode.
+	d.A = 10
+	d.H = 2.5
+	out, err := doc.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	doc2, err := DecodeConfig(out)
+	if err != nil {
+		t.Fatalf("re-decode: %v", err)
+	}
+	d2 := doc2.Data()
+	if d2.A != 10 {
+		t.Fatalf("re-decoded A = %d, want 10", d2.A)
+	}
+	if d2.H < 2.49 || d2.H > 2.51 {
+		t.Fatalf("re-decoded H = %f, want ~2.5", d2.H)
+	}
+}
+`)
+
+	cmd := exec.Command("go", "test", "-v", "./...")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOFLAGS=")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go test failed: %v\n%s", err, output)
+	}
+}
+
+func TestIntegrationSlicePointerPrimitive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	dir := t.TempDir()
+
+	repoRoot, err := filepath.Abs(filepath.Join("..", "."))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeFixture(t, dir, "go.mod", strings.Join([]string{
+		"module example.com/sliceptr",
+		"",
+		"go 1.26",
+		"",
+		"require github.com/amarbel-llc/tommy v0.0.0",
+		"",
+		"replace github.com/amarbel-llc/tommy => " + repoRoot,
+		"",
+	}, "\n"))
+
+	writeFixture(t, dir, "config.go", `package sliceptr
+
+//go:generate tommy generate
+type Config struct {
+	Names []*string `+"`"+`toml:"names"`+"`"+`
+	Ports []*int    `+"`"+`toml:"ports"`+"`"+`
+}
+`)
+
+	if err := Generate(dir, "config.go"); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	writeFixture(t, dir, "sliceptr_test.go", `package sliceptr
+
+import "testing"
+
+func TestSlicePointerPrimitiveRoundTrip(t *testing.T) {
+	input := []byte(`+"`"+`names = ["alice", "bob"]
+ports = [8080, 9090]
+`+"`"+`)
+
+	doc, err := DecodeConfig(input)
+	if err != nil {
+		t.Fatalf("DecodeConfig: %v", err)
+	}
+	d := doc.Data()
+	if len(d.Names) != 2 {
+		t.Fatalf("Names len = %d, want 2", len(d.Names))
+	}
+	if *d.Names[0] != "alice" {
+		t.Fatalf("Names[0] = %q, want %q", *d.Names[0], "alice")
+	}
+	if *d.Names[1] != "bob" {
+		t.Fatalf("Names[1] = %q, want %q", *d.Names[1], "bob")
+	}
+	if len(d.Ports) != 2 {
+		t.Fatalf("Ports len = %d, want 2", len(d.Ports))
+	}
+	if *d.Ports[0] != 8080 {
+		t.Fatalf("Ports[0] = %d, want 8080", *d.Ports[0])
+	}
+
+	// Modify and re-encode.
+	newName := "charlie"
+	d.Names[0] = &newName
+	out, err := doc.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	doc2, err := DecodeConfig(out)
+	if err != nil {
+		t.Fatalf("re-decode: %v", err)
+	}
+	d2 := doc2.Data()
+	if *d2.Names[0] != "charlie" {
+		t.Fatalf("re-decoded Names[0] = %q, want %q", *d2.Names[0], "charlie")
+	}
+}
+`)
+
+	cmd := exec.Command("go", "test", "-v", "./...")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOFLAGS=")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go test failed: %v\n%s", err, output)
+	}
+}
+
+func TestIntegrationMapStringPointerStruct(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	dir := t.TempDir()
+
+	repoRoot, err := filepath.Abs(filepath.Join("..", "."))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeFixture(t, dir, "go.mod", strings.Join([]string{
+		"module example.com/mapptr",
+		"",
+		"go 1.26",
+		"",
+		"require github.com/amarbel-llc/tommy v0.0.0",
+		"",
+		"replace github.com/amarbel-llc/tommy => " + repoRoot,
+		"",
+	}, "\n"))
+
+	writeFixture(t, dir, "config.go", `package mapptr
+
+//go:generate tommy generate
+type Config struct {
+	Servers map[string]*Server `+"`"+`toml:"servers"`+"`"+`
+}
+
+type Server struct {
+	Host string `+"`"+`toml:"host"`+"`"+`
+	Port int    `+"`"+`toml:"port"`+"`"+`
+}
+`)
+
+	if err := Generate(dir, "config.go"); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	writeFixture(t, dir, "mapptr_test.go", `package mapptr
+
+import "testing"
+
+func TestMapPointerStructRoundTrip(t *testing.T) {
+	input := []byte(`+"`"+`[servers.prod]
+host = "prod.example.com"
+port = 443
+
+[servers.dev]
+host = "dev.example.com"
+port = 8080
+`+"`"+`)
+
+	doc, err := DecodeConfig(input)
+	if err != nil {
+		t.Fatalf("DecodeConfig: %v", err)
+	}
+	d := doc.Data()
+	if len(d.Servers) != 2 {
+		t.Fatalf("Servers len = %d, want 2", len(d.Servers))
+	}
+	if d.Servers["prod"] == nil {
+		t.Fatal("Servers[prod] is nil")
+	}
+	if d.Servers["prod"].Host != "prod.example.com" {
+		t.Fatalf("Servers[prod].Host = %q, want %q", d.Servers["prod"].Host, "prod.example.com")
+	}
+	if d.Servers["prod"].Port != 443 {
+		t.Fatalf("Servers[prod].Port = %d, want 443", d.Servers["prod"].Port)
+	}
+	if d.Servers["dev"].Port != 8080 {
+		t.Fatalf("Servers[dev].Port = %d, want 8080", d.Servers["dev"].Port)
+	}
+
+	// Modify and re-encode.
+	d.Servers["prod"].Port = 8443
+	out, err := doc.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	doc2, err := DecodeConfig(out)
+	if err != nil {
+		t.Fatalf("re-decode: %v", err)
+	}
+	d2 := doc2.Data()
+	if d2.Servers["prod"].Port != 8443 {
+		t.Fatalf("re-decoded Servers[prod].Port = %d, want 8443", d2.Servers["prod"].Port)
+	}
+}
+`)
+
+	cmd := exec.Command("go", "test", "-v", "./...")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOFLAGS=")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go test failed: %v\n%s", err, output)
+	}
+}
+
+func TestIntegrationPointerStructWithSliceStruct(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	dir := t.TempDir()
+
+	repoRoot, err := filepath.Abs(filepath.Join("..", "."))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeFixture(t, dir, "go.mod", strings.Join([]string{
+		"module example.com/ptrslice",
+		"",
+		"go 1.26",
+		"",
+		"require github.com/amarbel-llc/tommy v0.0.0",
+		"",
+		"replace github.com/amarbel-llc/tommy => " + repoRoot,
+		"",
+	}, "\n"))
+
+	// Reproducer for #52: *Struct containing []Struct generates code
+	// that references undefined `d` receiver in DecodeInto/EncodeFrom.
+	writeFixture(t, dir, "config.go", `package ptrslice
+
+//go:generate tommy generate
+type Config struct {
+	Exec    *ExecConfig    `+"`"+`toml:"exec"`+"`"+`
+	Servers []ServerConfig `+"`"+`toml:"servers"`+"`"+`
+}
+
+type ExecConfig struct {
+	Allow []ExecRule `+"`"+`toml:"allow"`+"`"+`
+	Deny  []ExecRule `+"`"+`toml:"deny"`+"`"+`
+}
+
+type ExecRule struct {
+	Binary string            `+"`"+`toml:"binary"`+"`"+`
+	Args   []string          `+"`"+`toml:"args"`+"`"+`
+	Cwd    []string          `+"`"+`toml:"cwd"`+"`"+`
+	Env    map[string]string `+"`"+`toml:"env"`+"`"+`
+}
+
+type ServerConfig struct {
+	Name string `+"`"+`toml:"name"`+"`"+`
+}
+`)
+
+	if err := Generate(dir, "config.go"); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	writeFixture(t, dir, "ptrslice_test.go", `package ptrslice
+
+import "testing"
+
+func TestPointerStructWithSliceStruct(t *testing.T) {
+	input := []byte(`+"`"+`[[servers]]
+name = "grit"
+
+[exec]
+
+[[exec.allow]]
+binary = "go"
+args = ["build"]
+cwd = ["/tmp"]
+
+[[exec.deny]]
+binary = "rm"
+`+"`"+`)
+
+	doc, err := DecodeConfig(input)
+	if err != nil {
+		t.Fatalf("DecodeConfig: %v", err)
+	}
+	d := doc.Data()
+	if d.Exec == nil {
+		t.Fatal("Exec is nil")
+	}
+	if len(d.Exec.Allow) != 1 {
+		t.Fatalf("Allow len = %d, want 1", len(d.Exec.Allow))
+	}
+	if d.Exec.Allow[0].Binary != "go" {
+		t.Fatalf("Allow[0].Binary = %q, want %q", d.Exec.Allow[0].Binary, "go")
+	}
+	if len(d.Exec.Deny) != 1 {
+		t.Fatalf("Deny len = %d, want 1", len(d.Exec.Deny))
+	}
+	if len(d.Servers) != 1 {
+		t.Fatalf("Servers len = %d, want 1", len(d.Servers))
+	}
+
+	out, err := doc.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	doc2, err := DecodeConfig(out)
+	if err != nil {
+		t.Fatalf("re-decode: %v", err)
+	}
+	d2 := doc2.Data()
+	if d2.Exec.Allow[0].Binary != "go" {
+		t.Fatalf("re-decoded Allow[0].Binary = %q, want %q", d2.Exec.Allow[0].Binary, "go")
+	}
+}
+`)
+
+	cmd := exec.Command("go", "test", "-v", "./...")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOFLAGS=")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go test failed: %v\n%s", err, output)
+	}
+}
+
 func TestIntegrationArrayOfTables(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -513,10 +513,42 @@ func convertNode[T any](node *cst.Node) (T, error) {
 		var v int64
 		v, err = strconv.ParseInt(string(node.Raw), 10, 64)
 		result = int(v)
+	case int8:
+		var v int64
+		v, err = strconv.ParseInt(string(node.Raw), 10, 8)
+		result = int8(v)
+	case int16:
+		var v int64
+		v, err = strconv.ParseInt(string(node.Raw), 10, 16)
+		result = int16(v)
+	case int32:
+		var v int64
+		v, err = strconv.ParseInt(string(node.Raw), 10, 32)
+		result = int32(v)
 	case int64:
 		result, err = strconv.ParseInt(string(node.Raw), 10, 64)
+	case uint:
+		var v uint64
+		v, err = strconv.ParseUint(string(node.Raw), 10, 64)
+		result = uint(v)
+	case uint8:
+		var v uint64
+		v, err = strconv.ParseUint(string(node.Raw), 10, 8)
+		result = uint8(v)
+	case uint16:
+		var v uint64
+		v, err = strconv.ParseUint(string(node.Raw), 10, 16)
+		result = uint16(v)
+	case uint32:
+		var v uint64
+		v, err = strconv.ParseUint(string(node.Raw), 10, 32)
+		result = uint32(v)
 	case uint64:
 		result, err = strconv.ParseUint(string(node.Raw), 10, 64)
+	case float32:
+		var v float64
+		v, err = strconv.ParseFloat(string(node.Raw), 32)
+		result = float32(v)
 	case float64:
 		result, err = strconv.ParseFloat(string(node.Raw), 64)
 	case bool:
@@ -603,10 +635,27 @@ func encodeValue(value any) ([]byte, cst.NodeKind, error) {
 		return []byte(`"` + escapeString(v) + `"`), cst.NodeString, nil
 	case int:
 		return []byte(strconv.Itoa(v)), cst.NodeInteger, nil
+	case int8:
+		return []byte(strconv.FormatInt(int64(v), 10)), cst.NodeInteger, nil
+	case int16:
+		return []byte(strconv.FormatInt(int64(v), 10)), cst.NodeInteger, nil
+	case int32:
+		return []byte(strconv.FormatInt(int64(v), 10)), cst.NodeInteger, nil
 	case int64:
 		return []byte(strconv.FormatInt(v, 10)), cst.NodeInteger, nil
+	case uint:
+		return []byte(strconv.FormatUint(uint64(v), 10)), cst.NodeInteger, nil
+	case uint8:
+		return []byte(strconv.FormatUint(uint64(v), 10)), cst.NodeInteger, nil
+	case uint16:
+		return []byte(strconv.FormatUint(uint64(v), 10)), cst.NodeInteger, nil
+	case uint32:
+		return []byte(strconv.FormatUint(uint64(v), 10)), cst.NodeInteger, nil
 	case uint64:
 		return []byte(strconv.FormatUint(v, 10)), cst.NodeInteger, nil
+	case float32:
+		s := strconv.FormatFloat(float64(v), 'f', -1, 32)
+		return []byte(s), cst.NodeFloat, nil
 	case float64:
 		s := strconv.FormatFloat(v, 'f', -1, 64)
 		return []byte(s), cst.NodeFloat, nil


### PR DESCRIPTION
## Summary

Fixes 5 codegen bugs discovered by cross-referencing test patterns from BurntSushi/toml and pelletier/go-toml v2:

- **Self-referential struct crash**: `type Node struct { Child *Node }` caused infinite recursion in `resolveStructByName`. Added cycle detection via package-level `resolvingTypes` map.
- **Sized integers unrecognized**: `int8`/`int16`/`int32`, `uint`/`uint8`/`uint16`/`uint32`, `float32` fell through to `classifyNamedType`. Added to `primitiveTypes` map and `convertNode[T]`/`encodeValue` in document API.
- **`[]*primitive` misclassified as struct**: `[]*string` hit the `StarExpr` handler which only handled structs. Added `primitiveTypes` check with `SlicePointer=true`.
- **`map[string]*Struct` unsupported**: No `StarExpr` case in map value handler. Added with `SlicePointer=true`.
- **#52 — unused `tableNode` in encode for `*Struct` containing `[]Struct`**: `FieldSliceStruct` encode uses full dotted keys via `FindArrayTableNodes`/`AppendArrayTableEntry`, bypassing the container variable. Added `innerFieldsNeedContainer` to suppress the declaration when unneeded.

All bugs proven with failing tests first (TDD), then fixed.

Closes #52, closes #53.

## Test plan

- [x] All 5 unit tests in `analyze_test.go` pass
- [x] All 4 integration tests pass (sized integers, `[]*primitive`, `map[string]*Struct`, `*Struct` with `[]Struct`)
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)