### PR TITLE
fix(generate): nil []*Struct elements panicked encode; handle types collided

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,15 @@ hit the network in the sandbox); and the `fuzz-sweep` flake check loops the thre
 generative fuzzers (`TestRoundTripFuzz`, `TestRoundTripFuzzDelegation`,
 `TestRoundTripSpellingFuzz`) over many seeds (`fuzzSweepSeeds` in `flake.nix`) —
 the `go-generate` check runs them at seed 1 only, the sweep widens shape coverage
-per merge. When adding an emission edge case, add both a
+per merge. The value-space axis (which Go nil/empty/pointer shapes round-trip)
+is modeled by the representability fold (`generate/representability.go`, ADR
+2026-06-08) and held to generated-code reality by the conformance harness
+(`representability_conformance_test.go`); the fuzzers derive their nil/empty
+generation policy from that fold (`tdToSpk` + `reprOf`) rather than hand-coded
+exclusions. When adding an emission edge case, add both a
 bats test under `zz-tests_bats/` (tagged `generate`, e.g. `encode_wire_format.bats`)
-and a Go integration test for depth.
+and a Go integration test for depth; when changing encoder suppression/witness
+behavior, flip the matching conformance cell and the model axis together.
 
 ## CLI Commands
 

--- a/docs/decisions/2026-06-08-representability-in-the-type-ir.md
+++ b/docs/decisions/2026-06-08-representability-in-the-type-ir.md
@@ -4,14 +4,19 @@ date: 2026-06-08
 supersedes: n/a (complements 2026-06-07-decode-normalization)
 ---
 
-> **Draft for review (2026-06-08).** Proposed, not implemented as production.
+> **Draft for review (2026-06-08; examined and partially realized 2026-06-09).**
 > The motivating evidence (#1, #94, #121, #122, #123) is already fixed/filed;
 > this ADR records the *structural* direction those point at so it is decided
-> deliberately rather than rediscovered one cell at a time. Two concrete steps
-> already exist: the differential-decode test (commit e470a8b) is the empirical
-> gate, and a **prototype representability fold** (`generate/representability.go`
-> + test) validates that the model is a clean static computation — see Prototype
-> findings below.
+> deliberately rather than rediscovered one cell at a time. Realized so far:
+> the differential-decode test (commit e470a8b), the representability fold
+> (`generate/representability.go`) — rewritten 2026-06-09 to model the actual
+> encoder after an empirical probe falsified parts of the first prototype —
+> the cell-by-cell **conformance harness**
+> (`representability_conformance_test.go`) gating model against generated-code
+> reality, and the fuzzers' nil/empty generation policy now **derived from the
+> fold**. Still proposed: deriving the encoder/decoder themselves, closing the
+> encode-side empty witnesses, and the document-state axis. See Examination
+> findings (2026-06-09) below.
 
 # ADR: Model representability in the type IR (collapse the value-space axis)
 
@@ -133,12 +138,123 @@ and validate it against all four cells. What it confirmed and surfaced:
   case is silent-able even though `Server` alone always witnesses. From it,
   `pointerStructRoundTrips(S) = !structMayBeSilent(S)` predicts #122 exactly
   (`*Sub7{F0 []*Sub8}` → does not round-trip; `*Server{Host string}` → does).
+  *(2026-06-09: empirically disproven — see below. The encoder's table header
+  witnesses; the AND-over-fields rule was reasoning from an imagined encoder.)*
 - **The fold is type-level (worst-case "CAN be silent"); the fuzzer additionally
   needs a value-level check** ("does THIS value witness?"), or must restrict
   generation to the always-witnessing region. So the model yields a *predicate*
   for the encoder/decoder/exclusions and a *generation obligation* for the fuzzer.
 - **The one load-bearing assumption is the encoder's zero-value policy** — see
   the sharpened open question below. Everything else fell out cleanly.
+
+## Examination findings (2026-06-09): model the encoder we have, gate it empirically
+
+A second pass replaced reasoning-from-assumptions with an **empirical probe of
+every boundary cell against compiled generated code**, now committed as the
+standing conformance harness
+(`generate/representability_conformance_test.go`). The probe falsified parts
+of the first prototype and sharpened the theory. The fold
+(`representability.go`) was rewritten to model the renderer as it actually is.
+
+### The sharpened law
+
+Per field shape `T`, let `absent(T)` be what decode produces for a missing key
+(the Go zero: zero scalar, nil pointer/slice/map, zero struct) and `silent(T)`
+the set of values the encoder emits zero tokens for. Then:
+
+> every value of `T` round-trips  **iff**  `silent(T) ⊆ {absent(T)}`
+> and present-empty is witnessed where it is distinct.
+
+`MayBeSilent` alone was the wrong axis: silence is *harmless* when the silent
+value IS the absent-default (a zero scalar), and lossy only when it isn't (a
+non-nil pointer, a present-empty collection). The fold now carries
+`SilentFaithful` for exactly this distinction, plus a per-direction split of
+the old `EmptyDistinct` (below), and a composed `FullyFaithful` predicate.
+
+### What the probe established (each pinned by a conformance cell)
+
+1. **Zero scalars are silent but faithful.** A non-omitempty zero scalar emits
+   nothing into an empty document (`compSetPrimitive` gates on
+   `zero || HasValue`) and decodes back to zero. The prototype's "a
+   non-omitempty scalar always emits" assumption was wrong, yet harmless —
+   which is why no fuzzer ever caught it. Pointer scalars DO always emit
+   (`pb = false`). The zero-value policy open question below is therefore
+   answered: the generated encoder's policy is *suppress-unless-present*, and
+   it is faithful; what remains open is only marshal parity (#123).
+2. **The struct table header is the presence witness.** `&Wrapper{S: nil}`
+   emits `[w]` and round-trips — the AND-over-fields silence rule is false.
+   The ONLY silent struct is the #89 shape: every field a root-relative
+   array-of-tables, where the header is skipped (`compEncodeAllArrayTables`).
+   **#122 is precisely the #89 cosmetic rule applied behind a pointer**, where
+   silence stops being faithful (`absent = nil ≠ &AllTables{}`). The cell is
+   *positional*: the same shape inside a `[[list]]` entry or map sub-table
+   keeps its header and is faithful — so the fold threads a `scoped`
+   parameter, mirroring the position parameter the codegen folds thread.
+3. **The empty-collection asymmetry is encode-only.** The DECODERS already
+   read every present-empty form (`xs = []` → non-nil empty `[]struct` via
+   `compModelEmptyArrayLeaf`; a bare `[ms]` → non-nil empty
+   `map[string]struct`). Only the ENCODERS are entry-driven (`len > 0` gates
+   in `compEncMapStruct`/`compEncMapMap`/the array-table loops) and never emit
+   those forms. So the #1/#94 "unrepresentable" cells are not TOML
+   limitations — they are one-sided encoder suppression, and closing them is
+   an encoder-only change the decoders are already prepared for. `EmptyDistinct`
+   accordingly split into `EncodeWitnessesEmpty` / `DecodeReadsEmpty`.
+4. **`omitempty` is a leaf-only option.** `comp_build` threads `OmitEmpty`
+   into `ceLeaf` only; an omitempty scalar map still witnesses present-empty.
+5. **Nil container elements were a live panic, and the two container kinds
+   disagree.** Encoding `[]*Struct{nil, …}` dereferenced nil and panicked
+   (fixed 2026-06-09: skipped, matching `compSlicePrimSet`/`compEncMapStruct`
+   policy). But the map path creates the `[msp.k]` sub-table BEFORE its nil
+   check, so a nil map entry round-trips as a non-nil empty struct instead of
+   dropping — pinned in the harness as a (questionable) current policy.
+
+### Bugs the probe surfaced beyond the value-space axis
+
+- **Handle-type collision** (fixed 2026-06-09): two top-level `[]X` fields
+  sharing an element struct type generated two `xHandle` declarations — a
+  compile failure. Handle types are now named after the field.
+- **Stale array-table entries on shrink** (OPEN): decode a document with three
+  `[[servers]]` entries, truncate the slice to one, encode — all three entries
+  survive, because encode reuses found entries per index and never deletes the
+  tail. This is an instance of a whole untested axis: **encode output is a
+  function of (value, prior document)** — the `HasValue` zero-scalar rule and
+  entry reuse both read the prior document — but every fuzzer starts from an
+  empty document, so the second parameter is generatively unexercised.
+  Closing it needs a decode→mutate→encode harness (and an array-table
+  truncation fix).
+
+### Consumers wired so far
+
+- **The conformance harness** is the empirical gate: each cell records its
+  TypeExpr shape, which model axis decides it, and the verified outcome; the
+  test fails on either model drift (`predict(reprOf(shape)) != faithful`) or
+  renderer drift (generated-code behavior changes). Lossy cells are pinned, so
+  closing one later consciously flips the cell and the model together.
+- **The round-trip fuzzers' generation policy now DERIVES from the fold**
+  (`tdToSpk` + `reprOf` in `roundtrip_gen_test.go`), retiring the hand-coded
+  exclusion switch — which was a fifth hand-synced copy of the rules, written
+  in the fuzzer's own parallel `td` mini-algebra. Nil/empty variants are
+  generated exactly where the fold says they round-trip, which also *widened*
+  coverage (nil array-tables were previously never generated anywhere; now
+  they are everywhere except the guarded #122 position).
+
+### Remaining steps (in order of leverage)
+
+1. **Close the encode-side empty witnesses** (the #1/#94 cells): emit `= []`
+   for present-empty array-of-tables and a bare `[table]` for present-empty
+   struct-/named-map-valued maps. Decoders already read both; the conformance
+   cells and fold flip with the change. This shrinks the genuinely
+   unrepresentable residue to: nil container elements (TOML has no null) and
+   the deliberate omitempty collapse.
+2. **Re-examine the #89 header skip behind pointers**: emitting the parent
+   table header when a non-nil pointer struct's body is otherwise silent would
+   close #122 (the decoder already materializes `&S{}` from a bare header).
+   Cosmetic cost: a bare `[at]` section when entries exist is avoidable by
+   emitting it only when all array-table fields are empty.
+3. **The document-state axis**: a decode→mutate→encode generative harness, and
+   the array-table truncation fix it will immediately find.
+4. **Marshal parity (#123)** and differential fuzzing over the common subset,
+   as already proposed above.
 
 ## Risks / open questions
 

--- a/generate/comp_build.go
+++ b/generate/comp_build.go
@@ -70,16 +70,23 @@ func foldCompDecode(si *StructInfo, pos compPos, emitHandles bool) []cdNode {
 	for _, fi := range si.Fields {
 		siblingKeys[fi.TomlKey] = true
 	}
+	// handleOwner namespaces the generated entry-handle types by the directive
+	// struct (configServersHandle): handle types are file-scoped, so neither the
+	// element type nor the field name alone is collision-free across structs.
+	handleOwner := ""
+	if emitHandles {
+		handleOwner = si.Name
+	}
 	var out []cdNode
 	for _, fi := range si.Fields {
-		if n := foldCompDecodeField(fi, pos, emitHandles, siblingKeys); n != nil {
+		if n := foldCompDecodeField(fi, pos, handleOwner, siblingKeys); n != nil {
 			out = append(out, n)
 		}
 	}
 	return out
 }
 
-func foldCompDecodeField(fi FieldInfo, pos compPos, emitHandles bool, siblingKeys map[string]bool) cdNode {
+func foldCompDecodeField(fi FieldInfo, pos compPos, handleOwner string, siblingKeys map[string]bool) cdNode {
 	c := pos.child(fi.TomlKey, fi.GoName)
 
 	switch te := fi.Type.(type) {
@@ -111,7 +118,7 @@ func foldCompDecodeField(fi FieldInfo, pos compPos, emitHandles bool, siblingKey
 			}
 			return cdLeaf{Kind: cdLeafSlicePrim, Tgt: c.tgt, TKey: c.tkey, ElemType: elem.TypeName, TypeName: te.TypeName, ImportPath: te.ImportPath, SlicePointer: false}
 		case spkStruct:
-			return compDecodeArrayTable(fi, elem, c, false, emitHandles)
+			return compDecodeArrayTable(fi, elem, c, false, handleOwner)
 		case spkDelegated:
 			return cdDelSlice{Tgt: c.tgt, TKey: StaticKey(fi.TomlKey), TDottedKey: c.tkey, ImportPath: elem.ImportPath, TypeName: elem.TypeName, SlicePtr: false, IdxVar: arrayIdxVar(c.arrayDepth)}
 		case spkPtr:
@@ -121,7 +128,7 @@ func foldCompDecodeField(fi FieldInfo, pos compPos, emitHandles bool, siblingKey
 				// element type is on the inner scalar.
 				return cdLeaf{Kind: cdLeafSlicePrim, Tgt: c.tgt, TKey: c.tkey, ElemType: pe.TypeName, TypeName: te.TypeName, ImportPath: te.ImportPath, SlicePointer: true}
 			case spkStruct:
-				return compDecodeArrayTable(fi, pe, c, true, emitHandles)
+				return compDecodeArrayTable(fi, pe, c, true, handleOwner)
 			case spkDelegated:
 				return cdDelSlice{Tgt: c.tgt, TKey: StaticKey(fi.TomlKey), TDottedKey: c.tkey, ImportPath: pe.ImportPath, TypeName: pe.TypeName, SlicePtr: true, IdxVar: arrayIdxVar(c.arrayDepth)}
 			}
@@ -188,7 +195,7 @@ func compDecodeFlatChildren(inner *StructInfo, c compPos, tgt TargetPath, siblin
 		if isSliceOfStruct(f.Type) {
 			pos.tkey = c.tkey
 		}
-		if n := foldCompDecodeField(f, pos, false, nil); n != nil {
+		if n := foldCompDecodeField(f, pos, "", nil); n != nil {
 			if isSliceOfStruct(f.Type) {
 				// Scoped flat fallback (#105): this struct's [header] is absent, so
 				// its array-table field is searched in the parent scope. Use the key
@@ -277,7 +284,7 @@ func compDecodeNilGuard(fi FieldInfo, st spkStruct, c compPos, siblingKeys map[s
 	return cdNilGuard{Tgt: c.tgt, TypeName: st.TypeName, TKey: c.tkey, LocalVar: localVar, Children: children, FlatChildren: flat}
 }
 
-func compDecodeArrayTable(fi FieldInfo, st spkStruct, c compPos, slicePtr, emitHandles bool) cdNode {
+func compDecodeArrayTable(fi FieldInfo, st spkStruct, c compPos, slicePtr bool, handleOwner string) cdNode {
 	if st.InnerInfo == nil {
 		return nil
 	}
@@ -290,7 +297,8 @@ func compDecodeArrayTable(fi FieldInfo, st spkStruct, c compPos, slicePtr, emitH
 		TKey:         StaticKey(fi.TomlKey),
 		TDottedKey:   c.tkey,
 		SlicePtr:     slicePtr,
-		TrackHandles: emitHandles && !crossPkg,
+		TrackHandles: handleOwner != "" && !crossPkg,
+		HandleType:   handleTypeName(handleOwner, fi.GoName),
 		IdxVar:       iv,
 		EntryVar:     arrayEntryVar(c.arrayDepth),
 		Children:     foldCompDecode(st.InnerInfo, compPos{tkey: c.tkey, tgt: c.tgt.Index(iv), arrayDepth: c.arrayDepth + 1, seq: c.seq}, false),

--- a/generate/comp_decode_model.go
+++ b/generate/comp_decode_model.go
@@ -245,18 +245,16 @@ func compModelArrayTable(ctx jenCtx, g *jen.Group, n cdArrayTable, tv *jen.State
 			b.Add(n.Tgt.Jen().Clone()).Op("=").Make(jen.Index().Add(jt.Clone()), jen.Len(v.Clone().Dot("Items")))
 		}
 		if n.TrackHandles {
-			hn := toLowerFirst(n.TypeName) + "Handle"
 			fn := toLowerFirst(n.Tgt.Segs[len(n.Tgt.Segs)-1].Name)
-			b.Id("d").Dot(fn).Op("=").Make(jen.Index().Id(hn), jen.Len(v.Clone().Dot("Items")))
+			b.Id("d").Dot(fn).Op("=").Make(jen.Index().Id(n.HandleType), jen.Len(v.Clone().Dot("Items")))
 		}
 		ev := "_e" + n.TDottedKey.VarSuffix()
 		b.For(jen.Id(n.IdxVar).Op(":=").Range().Add(v.Clone()).Dot("Items")).BlockFunc(func(lb *jen.Group) {
 			lb.Id(ev).Op(":=").Op("&").Add(v.Clone()).Dot("Items").Index(jen.Id(n.IdxVar))
 			lb.Add(jen.Id(ev).Dot("MarkSeen").Call())
 			if n.TrackHandles {
-				hn := toLowerFirst(n.TypeName) + "Handle"
 				fn := toLowerFirst(n.Tgt.Segs[len(n.Tgt.Segs)-1].Name)
-				lb.Id("d").Dot(fn).Index(jen.Id(n.IdxVar)).Op("=").Id(hn).Values(jen.Dict{jen.Id("node"): jen.Id(ev).Dot("Node")})
+				lb.Id("d").Dot(fn).Index(jen.Id(n.IdxVar)).Op("=").Id(n.HandleType).Values(jen.Dict{jen.Id("node"): jen.Id(ev).Dot("Node")})
 			}
 			if n.SlicePtr {
 				lb.Add(n.Tgt.Jen().Clone()).Index(jen.Id(n.IdxVar)).Op("=").Op("&").Add(jt.Clone()).Values()

--- a/generate/comp_ir.go
+++ b/generate/comp_ir.go
@@ -83,6 +83,7 @@ type cdArrayTable struct {
 	TDottedKey   TOMLKey // full dotted key
 	SlicePtr     bool
 	TrackHandles bool
+	HandleType   string // generated handle type name (handleTypeName); set iff TrackHandles
 	IdxVar       string
 	EntryVar     string
 	// ScopedFlatKey, when non-empty, is the lookup key the SCOPED renderer uses

--- a/generate/comp_render.go
+++ b/generate/comp_render.go
@@ -354,12 +354,21 @@ func compEncNilGuard(ctx encCtx, n ceNilGuard, cv *jen.Statement) []jen.Code {
 func compEncArrayTable(ctx encCtx, n ceArrayTable, cv *jen.Statement) []jen.Code {
 	src := n.Tgt.Jen()
 	bk := n.TKey.BareKey()
+	// A nil element of a []*Struct has no TOML representation (no null): skip it
+	// on encode — the policy compEncMapStruct and compSlicePrimSet already apply —
+	// instead of dereferencing it and panicking.
+	skipNilElem := func(g *jen.Group) {
+		if n.SlicePtr {
+			g.If(src.Clone().Index(jen.Id(n.IdxVar)).Op("==").Nil()).Block(jen.Continue())
+		}
+	}
 	return []jen.Code{jen.BlockFunc(func(g *jen.Group) {
 		if n.TrackHandles {
 			// Top-level same-package []struct: reuse the decode-recorded entry
 			// handles; new entries append at the document root.
 			handleSlice := "d." + toLowerFirst(n.Tgt.Segs[len(n.Tgt.Segs)-1].Name)
 			g.For(jen.Id(n.IdxVar).Op(":=").Range().Add(src.Clone())).BlockFunc(func(g *jen.Group) {
+				skipNilElem(g)
 				g.Var().Id("container").Op("*").Qual(cstPkg, "Node")
 				g.If(jen.Id(n.IdxVar).Op("<").Len(jen.Id(handleSlice))).Block(
 					jen.Id("container").Op("=").Id(handleSlice).Index(jen.Id(n.IdxVar)).Dot("node"),
@@ -380,6 +389,7 @@ func compEncArrayTable(ctx encCtx, n ceArrayTable, cv *jen.Statement) []jen.Code
 			g.Id(pv).Op(":=").Add(cv.Clone())
 			g.Id(existVar).Op(":=").Qual(cstPkg, "FindChildArrayTableNodes").Call(ctx.rootVar.Clone(), jen.Id(pv), jen.Lit(bk))
 			g.For(jen.Id(n.IdxVar).Op(":=").Range().Add(src.Clone())).BlockFunc(func(g *jen.Group) {
+				skipNilElem(g)
 				g.Var().Id("container").Op("*").Qual(cstPkg, "Node")
 				g.If(jen.Id(n.IdxVar).Op("<").Len(jen.Id(existVar))).Block(
 					jen.Id("container").Op("=").Id(existVar).Index(jen.Id(n.IdxVar)),
@@ -397,6 +407,7 @@ func compEncArrayTable(ctx encCtx, n ceArrayTable, cv *jen.Statement) []jen.Code
 			existVar := "_exist" + n.TDottedKey.VarSuffix()
 			g.Id(existVar).Op(":=").Qual(cstPkg, "FindArrayTableNodes").Call(ctx.rootVar.Clone(), n.TDottedKey.Jen())
 			g.For(jen.Id(n.IdxVar).Op(":=").Range().Add(src.Clone())).BlockFunc(func(g *jen.Group) {
+				skipNilElem(g)
 				g.Var().Id("container").Op("*").Qual(cstPkg, "Node")
 				g.If(jen.Id(n.IdxVar).Op("<").Len(jen.Id(existVar))).Block(
 					jen.Id("container").Op("=").Id(existVar).Index(jen.Id(n.IdxVar)),
@@ -465,6 +476,13 @@ func compEncDelSlice(ctx encCtx, n ceDelSlice, cv *jen.Statement) []jen.Code {
 	existVar := "_exist" + n.TDottedKey.VarSuffix()
 	pv := "_ap" + n.TDottedKey.VarSuffix()
 
+	// Nil []*Struct elements are skipped, mirroring compEncArrayTable: TOML has
+	// no null, and the delegated EncodeFrom would dereference nil.
+	skipNilElem := func(g *jen.Group) {
+		if n.SlicePtr {
+			g.If(src.Clone().Index(jen.Id(n.IdxVar)).Op("==").Nil()).Block(jen.Continue())
+		}
+	}
 	entry := func(g *jen.Group) {
 		if n.SlicePtr {
 			g.If(jen.Err().Op(":=").Qual(n.ImportPath, encFn).Call(
@@ -482,6 +500,7 @@ func compEncDelSlice(ctx encCtx, n ceDelSlice, cv *jen.Statement) []jen.Code {
 			g.Id(pv).Op(":=").Add(cv.Clone())
 			g.Id(existVar).Op(":=").Qual(cstPkg, "FindChildArrayTableNodes").Call(ctx.rootVar.Clone(), jen.Id(pv), jen.Lit(bk))
 			g.For(jen.Id(n.IdxVar).Op(":=").Range().Add(src.Clone())).BlockFunc(func(g *jen.Group) {
+				skipNilElem(g)
 				g.Var().Id("container").Op("*").Qual(cstPkg, "Node")
 				g.If(jen.Id(n.IdxVar).Op("<").Len(jen.Id(existVar))).Block(
 					jen.Id("container").Op("=").Id(existVar).Index(jen.Id(n.IdxVar)),
@@ -493,6 +512,7 @@ func compEncDelSlice(ctx encCtx, n ceDelSlice, cv *jen.Statement) []jen.Code {
 		} else {
 			g.Id(existVar).Op(":=").Qual(cstPkg, "FindArrayTableNodes").Call(ctx.rootVar.Clone(), n.TDottedKey.Jen())
 			g.For(jen.Id(n.IdxVar).Op(":=").Range().Add(src.Clone())).BlockFunc(func(g *jen.Group) {
+				skipNilElem(g)
 				g.Var().Id("container").Op("*").Qual(cstPkg, "Node")
 				g.If(jen.Id(n.IdxVar).Op("<").Len(jen.Id(existVar))).Block(
 					jen.Id("container").Op("=").Id(existVar).Index(jen.Id(n.IdxVar)),
@@ -553,9 +573,12 @@ func RenderFile(w io.Writer, pkg string, structs []StructInfo) error {
 
 func compEmitStruct(f *jen.File, si StructInfo) {
 	dt := si.Name + "Document"
+	// Handle types are named struct+field (handleTypeName): they are file-scoped
+	// declarations, so naming by element type alone collided when two slice
+	// fields (or two structs' fields) shared an element struct.
 	for _, fi := range si.Fields {
 		if isSamePackageSliceStruct(fi) {
-			f.Type().Id(unexport(sliceStructName(fi)) + "Handle").Struct(jen.Id("node").Op("*").Qual(cstPkg, "Node"))
+			f.Type().Id(handleTypeName(si.Name, fi.GoName)).Struct(jen.Id("node").Op("*").Qual(cstPkg, "Node"))
 		}
 	}
 	f.Type().Id(dt).StructFunc(func(g *jen.Group) {
@@ -564,7 +587,7 @@ func compEmitStruct(f *jen.File, si StructInfo) {
 		g.Id("model").Op("*").Qual(cstPkg, "Value")
 		for _, fi := range si.Fields {
 			if isSamePackageSliceStruct(fi) {
-				g.Id(unexport(fi.GoName)).Index().Id(unexport(sliceStructName(fi)) + "Handle")
+				g.Id(unexport(fi.GoName)).Index().Id(handleTypeName(si.Name, fi.GoName))
 			}
 		}
 	})

--- a/generate/render_helpers.go
+++ b/generate/render_helpers.go
@@ -72,11 +72,13 @@ func isSamePackageSliceStruct(fi FieldInfo) bool {
 	return ok && !strings.Contains(st.TypeName, ".")
 }
 
-// sliceStructName is the element struct's type name for a same-package
-// slice-struct field (the basis of its generated Handle type name).
-func sliceStructName(fi FieldInfo) string {
-	st, _ := sliceStructElem(fi)
-	return st.TypeName
+// handleTypeName names the generated entry-handle type for a top-level
+// same-package slice-struct field: owner struct + field (configServersHandle).
+// Handle types are file-scoped, so the name must be unique across both the
+// fields of one struct (two []Server fields) and the structs of one file (two
+// structs with an F0 []Sub field).
+func handleTypeName(owner, fieldGoName string) string {
+	return unexport(owner) + fieldGoName + "Handle"
 }
 
 // collectImportPaths returns the cross-package import paths referenced by the

--- a/generate/representability.go
+++ b/generate/representability.go
@@ -1,80 +1,203 @@
 package generate
 
-// Representability fold (PROTOTYPE — ADR 2026-06-08). A fold over the TypeExpr
-// IR that makes explicit which Go value shapes have a faithful TOML round-trip.
-// It is not yet wired into the encoder / decoders / fuzzer; it exists to validate
-// that the model is a clean static computation and to surface its hidden
-// assumptions (see the ADR's open questions). The four bug cells it must predict:
+// Representability fold (ADR 2026-06-08; sharpened 2026-06-09). A fold over the
+// TypeExpr IR that makes explicit which Go value shapes have a faithful TOML
+// round-trip under the GENERATED encoder/decoder pair. Unlike the first
+// prototype — which reasoned from assumed encoder behavior — this version models
+// the renderer as it actually is, and is held to that empirically by the
+// conformance harness (representability_conformance_test.go): every claim below
+// is asserted against compiled generated code, so the model cannot silently
+// drift from the implementation.
 //
-//   #1   empty `xs = []` into []struct collapses to nil (no present-empty form)
-//   #121 empty `xs = []` into []scalar round-trips as a non-nil empty slice
-//   #94  the fuzzer must know which empty/nil variants are representable
-//   #122 a non-nil pointer to an all-silent struct body round-trips to nil
+// The round-trip law it makes checkable, per field shape T:
 //
-// The eventual goal (ADR): the encoder's suppression, the decoders' nil/empty
-// normalization, and the fuzzer's generation policy all DERIVE from this fold,
-// instead of being hand-maintained in four places that drift apart.
+//	decode(encode(v)) == v   for all v of T   iff   silent(T) ⊆ {absent(T)}
+//	                                                and empty witnesses where distinct
+//
+// where absent(T) is the value decode produces when the key is missing (the Go
+// zero value: zero scalar, nil pointer/slice/map, zero struct), and silent(T) is
+// the set of values the encoder emits zero tokens for. Silence is harmless
+// exactly when the silent value IS the absent-default (a zero scalar); it is a
+// lossy cell when it isn't (a non-nil pointer, a present-empty collection).
+//
+// Encoder facts the fold encodes (each pinned by a conformance cell):
+//
+//   - A non-omitempty zero SCALAR is suppressed unless the key already exists in
+//     the document (compSetPrimitive) — silent, but faithful: absent decodes to
+//     the same zero. (This also makes encode output depend on the PRIOR document
+//     state — see the ADR's document-state axis.)
+//   - A non-nil POINTER SCALAR always emits, zero or not.
+//   - A struct field (value or pointer) witnesses its presence with its [table]
+//     header — EXCEPT when every child is a root-relative array-table, where the
+//     #89 no-spurious-bare-section rule skips the header (compEncTable /
+//     compEncNilGuard / compEncodeAllArrayTables). Behind a pointer that
+//     exception is the #122 lossy cell: an all-silent body collapses to nil.
+//     Delegated structs always emit their header (compEncDelStruct).
+//   - []scalar and map[string]scalar witness present-empty (`= []`, a bare
+//     `[table]`); []struct, map[string]struct and map[string]NamedMap do NOT
+//     (their encoders are entry-driven: zero entries, zero tokens) — even though
+//     the DECODERS read those present-empty forms (compModelEmptyArrayLeaf, the
+//     VTable map readers). That encode/decode asymmetry is the #1/#94 cell.
+//   - Nil container ELEMENTS are skipped on encode (TOML has no null):
+//     []*scalar, []*struct, map[string]*struct all drop nil entries.
+//
+// Position matters: the #89 header skip applies only to fields reached through
+// root-relative table nesting. Inside an array-table entry or a map sub-table
+// the entry/sub-table header always witnesses, so the same struct shape can be
+// lossy at the document root and faithful inside a [[list]] entry. The fold
+// threads that as the `scoped` parameter.
 
 // repr is the representability descriptor for a field's TypeExpr.
 type repr struct {
 	// MayBeSilent reports whether SOME value of this field encodes to zero TOML
-	// tokens — indistinguishable from absence on decode. A non-nil pointer to a
-	// MayBeSilent body has values that do not round-trip (#122); a faithful
-	// generator must not emit those silent values.
+	// tokens into an empty document — indistinguishable from absence on decode.
 	MayBeSilent bool
-	// EmptyDistinct reports whether a present-but-empty value has a TOML encoding
-	// distinct from absence, so empty round-trips as non-nil empty rather than
-	// collapsing to nil. True for []scalar / map[string]scalar (`= []`, empty
-	// `[table]`); false for array-of-tables and map[string]struct (#1/#94).
-	EmptyDistinct bool
+	// SilentFaithful reports whether every silent value equals the decode-absent
+	// default, i.e. silence never loses information. A zero scalar is silent and
+	// faithful; a non-nil *AllArrayTables body is silent and NOT faithful (#122);
+	// a present-empty []struct is silent and NOT faithful (#1).
+	SilentFaithful bool
+	// EncodeWitnessesEmpty reports whether the ENCODER emits a present-empty
+	// form for an empty (non-nil) collection: `= []` / a bare `[table]`. True
+	// for []scalar and map[string]scalar; false for array-of-tables and
+	// struct-/named-map-valued maps, whose encoders are entry-driven.
+	EncodeWitnessesEmpty bool
+	// DecodeReadsEmpty reports whether the DECODER maps an explicit present-empty
+	// form to a non-nil empty collection. True for every collection kind — the
+	// decoders gained the empty forms in #1/#94 — which is what makes
+	// EncodeWitnessesEmpty=false an asymmetry rather than a shared limitation.
+	DecodeReadsEmpty bool
+	// FullyFaithful reports whether EVERY value of this shape round-trips
+	// (decode∘encode == id from an empty document). This is the predicate the
+	// fuzzer's generation policy derives from: a fully-faithful shape needs no
+	// value exclusions at all.
+	FullyFaithful bool
 }
 
 // reprOf folds the representability model over a field's TypeExpr. omitEmpty is
 // the field's `,omitempty` tag, which widens the silent set (a zero/empty value
-// is dropped entirely).
-//
-// PROTOTYPE ASSUMPTION: a non-omitempty scalar always emits its `key = value`
-// (even the zero value), which is what the round-trip fuzzer relies on — it
-// fills scalars with non-zero samples. The reflection encoder's additional
-// "skip a zero value that isn't already in the document" rule is deliberately
-// NOT modelled here; reconciling the generated and reflection encoders'
-// zero-value policy is exactly the hidden contract this fold is meant to force
-// into the open (ADR open question #1).
-func reprOf(t spkType, omitEmpty bool) repr {
+// is dropped entirely — a deliberate, user-requested collapse, so it shows up
+// here as lost faithfulness at empty). scoped reports whether the field lives
+// inside an array-table entry or map sub-table (whose header always witnesses)
+// rather than root-relative table nesting (where #89 can skip the header).
+func reprOf(t spkType, omitEmpty bool, scoped bool) repr {
 	switch s := t.(type) {
 	case spkScalar:
-		return repr{MayBeSilent: omitEmpty, EmptyDistinct: false}
+		// Zero suppression makes the zero value silent even without omitempty,
+		// but absent decodes to the same zero: silent yet faithful either way.
+		return repr{MayBeSilent: true, SilentFaithful: true, FullyFaithful: true}
 	case spkPtr:
-		// A nil pointer is silent; the field is therefore always potentially silent.
-		return repr{MayBeSilent: true, EmptyDistinct: false}
+		return reprPtr(s, scoped)
 	case spkSlice:
-		// A nil slice is silent (omitted). A []scalar has a present-empty form
-		// (`= []`) distinct from nil; an array-of-tables ([]struct / []*struct)
-		// does not.
-		return repr{MayBeSilent: true, EmptyDistinct: !elemIsStructish(s.Elem)}
+		if elemIsStructish(s.Elem) {
+			// Array-of-tables: entry-driven encode → empty is silent and collapses
+			// to nil, though decode reads an explicit `= []` (#1/#94). A pointer
+			// element can additionally be nil, which encode skips (lossy).
+			return repr{MayBeSilent: true, SilentFaithful: false,
+				EncodeWitnessesEmpty: false, DecodeReadsEmpty: true, FullyFaithful: false}
+		}
+		// []scalar: nil omits (faithful), empty emits `= []` — unless omitempty,
+		// which collapses empty to absent (decodes nil ≠ empty: lossy at empty).
+		return repr{MayBeSilent: true, SilentFaithful: !omitEmpty,
+			EncodeWitnessesEmpty: !omitEmpty, DecodeReadsEmpty: true, FullyFaithful: !omitEmpty}
 	case spkMap:
-		// A nil map is silent. map[string]scalar has a present-empty form (an empty
-		// `[table]`); map[string]struct does not.
-		return repr{MayBeSilent: true, EmptyDistinct: !elemIsStructish(s.Elem)}
+		if elemIsStructish(s.Elem) || isMapType(s.Elem) {
+			// map[string]struct / map[string]NamedMap: entry-driven encode
+			// (compEncMapStruct / compEncMapMap gate on len > 0) → empty silent,
+			// though decode materializes a non-nil map from a bare [table].
+			return repr{MayBeSilent: true, SilentFaithful: false,
+				EncodeWitnessesEmpty: false, DecodeReadsEmpty: true, FullyFaithful: false}
+		}
+		// map[string]scalar: nil omits, non-nil (incl. empty) emits its [table]
+		// header. compSetMapScalar has no omitempty branch, so the tag does not
+		// widen the silent set here.
+		return repr{MayBeSilent: true, SilentFaithful: true,
+			EncodeWitnessesEmpty: true, DecodeReadsEmpty: true, FullyFaithful: true}
 	case spkStruct:
-		return repr{MayBeSilent: structMayBeSilent(s.InnerInfo), EmptyDistinct: false}
+		// A VALUE struct field is always faithful in itself: when its header is
+		// emitted it witnesses; when #89 skips the header the silent value is an
+		// all-absent-default body, which is exactly what decode-absent produces.
+		// Lossiness can only come from its children.
+		return repr{
+			MayBeSilent:    structMayBeSilent(s.InnerInfo, scoped),
+			SilentFaithful: true,
+			FullyFaithful:  structFullyFaithful(s.InnerInfo, scoped),
+		}
 	case spkDelegated:
-		return repr{MayBeSilent: structMayBeSilent(s.InnerInfo), EmptyDistinct: false}
+		// Delegated structs always emit their table header on encode.
+		return repr{MayBeSilent: false, SilentFaithful: true,
+			FullyFaithful: structFullyFaithful(s.InnerInfo, true)}
 	}
 	return repr{MayBeSilent: true}
 }
 
-// structMayBeSilent reports whether a struct can encode to zero tokens — true
-// iff EVERY field can simultaneously be silent. A single always-emitting field
-// (e.g. a non-omitempty scalar) makes the struct always witness its presence, so
-// a non-nil pointer to it always round-trips. This is the recursive crux: the
-// property is bottom-up over the struct's fields.
-func structMayBeSilent(si *StructInfo) bool {
+// reprPtr models pointer fields. Nil is silent and faithful (absent decodes to
+// nil). A NON-nil pointer witnesses via its scalar value or its struct table
+// header — except a root-relative same-package struct whose children are all
+// array-tables (#89 skips the header): values with an all-silent body then
+// collapse to nil on decode, the #122 cell.
+func reprPtr(p spkPtr, scoped bool) repr {
+	switch e := p.Elem.(type) {
+	case spkStruct:
+		if structHeaderSkipped(e.InnerInfo, scoped) {
+			return repr{MayBeSilent: true, SilentFaithful: false, FullyFaithful: false}
+		}
+		return repr{MayBeSilent: true, SilentFaithful: true,
+			FullyFaithful: structFullyFaithful(e.InnerInfo, scoped)}
+	case spkDelegated:
+		return repr{MayBeSilent: true, SilentFaithful: true,
+			FullyFaithful: structFullyFaithful(e.InnerInfo, true)}
+	default:
+		// *scalar: a non-nil pointer always emits `key = value`, zero included
+		// (compSetPrimitive's pointer path has no zero suppression).
+		return repr{MayBeSilent: true, SilentFaithful: true, FullyFaithful: true}
+	}
+}
+
+// structHeaderSkipped mirrors compEncodeAllArrayTables: a root-relative struct
+// whose every field is an array-of-tables (same-package or delegated, possibly
+// of pointer elements) gets no parent [table] header on encode — the [[a.b]]
+// headers imply it when entries exist, and nothing witnesses when they don't.
+// Scoped structs (inside an array-table entry or map sub-table) always keep
+// their header. nil InnerInfo (an unresolved skeleton) assumes the worst case.
+func structHeaderSkipped(si *StructInfo, scoped bool) bool {
+	if scoped {
+		return false
+	}
 	if si == nil {
-		return true // unresolved skeleton (fieldType path): assume the worst case
+		return true
+	}
+	if len(si.Fields) == 0 {
+		return false
 	}
 	for _, f := range si.Fields {
-		if !reprOf(f.Type, f.OmitEmpty).MayBeSilent {
+		s, ok := f.Type.(spkSlice)
+		if !ok || !elemIsStructish(s.Elem) {
+			return false
+		}
+	}
+	return true
+}
+
+// structMayBeSilent reports whether a struct field can encode to zero tokens.
+// With its header emitted it always witnesses; without one (the #89 skip) the
+// all-nil/empty body is silent. This replaces the first prototype's AND-over-
+// fields recursion, which the conformance harness disproved: a struct holding
+// only a nil *Server still witnesses via its own [table] header.
+func structMayBeSilent(si *StructInfo, scoped bool) bool {
+	return structHeaderSkipped(si, scoped)
+}
+
+// structFullyFaithful reports whether every value of the struct round-trips:
+// the conjunction of its fields' faithfulness. Fields of a value/pointer struct
+// keep their parent's position (table nesting extends the path); the entry
+// bodies of array-tables and struct-maps are scoped by their own reprOf cases.
+func structFullyFaithful(si *StructInfo, scoped bool) bool {
+	if si == nil {
+		return false // unresolved skeleton: cannot vouch for the body
+	}
+	for _, f := range si.Fields {
+		if !reprOf(f.Type, f.OmitEmpty, scoped).FullyFaithful {
 			return false
 		}
 	}
@@ -82,7 +205,8 @@ func structMayBeSilent(si *StructInfo) bool {
 }
 
 // elemIsStructish reports whether a slice/map element decodes as an array-of-
-// tables / sub-table (which has no present-empty form) rather than a scalar leaf.
+// tables / sub-table (which the encoder gives no present-empty form) rather
+// than a scalar leaf.
 func elemIsStructish(t spkType) bool {
 	switch s := t.(type) {
 	case spkStruct, spkDelegated:
@@ -94,10 +218,10 @@ func elemIsStructish(t spkType) bool {
 	}
 }
 
-// pointerStructRoundTrips reports whether EVERY non-nil value of *struct(si)
-// round-trips. False means some non-nil pointer — one whose struct body is in an
-// all-silent state — collapses to nil on decode (#122): the encoder cannot
-// witness its presence and a faithful generator must not produce it.
-func pointerStructRoundTrips(si *StructInfo) bool {
-	return !structMayBeSilent(si)
+// isMapType reports whether the element is itself a map (the
+// map[string]NamedMap shape, whose encoder is entry-driven like the struct
+// maps).
+func isMapType(t spkType) bool {
+	_, ok := t.(spkMap)
+	return ok
 }

--- a/generate/representability_conformance_test.go
+++ b/generate/representability_conformance_test.go
@@ -1,0 +1,300 @@
+package generate
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Conformance harness for the representability fold (ADR 2026-06-08): every
+// claim the model makes about a value-space boundary cell is asserted against
+// COMPILED GENERATED CODE, so the static model and the renderer cannot drift
+// apart silently — the failure names the cell. Cells cover both faithful and
+// lossy regions: lossy cells are pinned (encode is silent, decode collapses to
+// the absent default), so closing one later (e.g. teaching the encoder a
+// present-empty witness) consciously flips a cell here AND the model together.
+//
+// Each cell records: the TypeExpr shape (for the fold), which model axis
+// decides it (predict), and the empirically verified outcome (faithful). The
+// generate-side check `predict(reprOf(shape)) == faithful` fails fast on model
+// drift; the generated test then verifies `faithful` against reality.
+
+type confCell struct {
+	name      string
+	shape     spkType
+	omitEmpty bool
+	// predict picks the model axis that decides this cell's value class.
+	predict func(repr) bool
+	// faithful is the empirically verified truth: does the cell's value
+	// round-trip? When false the value collapses to the absent default (the
+	// zero Config field), which the generated assertion encodes.
+	faithful bool
+	// setLit populates the cell's value on *d.Data() (variable c).
+	setLit string
+	// wantLit is the full expected Config literal when faithful.
+	wantLit string
+	// wire, when non-empty, must appear in the encoded TOML (a presence
+	// witness); wireSilent instead requires the encoded TOML to be empty
+	// (the value is in the encoder's silent region).
+	wire       string
+	wireSilent bool
+}
+
+func TestRepresentabilityConformance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	// Shapes mirroring the fixture package below.
+	server := &StructInfo{Name: "Server", Fields: []FieldInfo{
+		{GoName: "Host", TomlKey: "host", Type: spkScalar{Codec: codecPrim, TypeName: "string"}},
+	}}
+	serverT := spkStruct{TypeName: "Server", InnerInfo: server}
+	wrapper := &StructInfo{Name: "Wrapper", Fields: []FieldInfo{
+		{GoName: "S", TomlKey: "s", Type: spkPtr{Elem: serverT}},
+	}}
+	allTables := &StructInfo{Name: "AllTables", Fields: []FieldInfo{
+		{GoName: "Xs", TomlKey: "xs", Type: spkSlice{Elem: serverT}},
+	}}
+	boolT := spkScalar{Codec: codecPrim, TypeName: "bool"}
+	stringT := spkScalar{Codec: codecPrim, TypeName: "string"}
+
+	cells := []confCell{
+		{
+			// A non-omitempty zero scalar is suppressed (no `b = false` in an
+			// empty doc) but decodes back to zero: silent AND faithful.
+			name: "zero-scalar-silent-faithful", shape: boolT,
+			predict: func(r repr) bool { return r.MayBeSilent && r.SilentFaithful },
+			faithful: true, setLit: `c.B = false`, wantLit: `Config{}`, wireSilent: true,
+		},
+		{
+			// A non-nil pointer scalar always witnesses, zero included.
+			name: "ptr-zero-scalar-witnesses", shape: spkPtr{Elem: boolT},
+			predict:  func(r repr) bool { return r.FullyFaithful },
+			faithful: true, setLit: `v := false; c.PB = &v`, wantLit: `Config{PB: ptr(false)}`, wire: "pb = false",
+		},
+		{
+			// #121: empty []scalar witnesses with `= []`.
+			name: "empty-prim-slice", shape: spkSlice{Elem: stringT},
+			predict:  func(r repr) bool { return r.EncodeWitnessesEmpty },
+			faithful: true, setLit: `c.Tags = []string{}`, wantLit: `Config{Tags: []string{}}`, wire: "tags = []",
+		},
+		{
+			// omitempty collapses empty to absent: lossy at empty, by request.
+			name: "empty-prim-slice-omitempty", shape: spkSlice{Elem: stringT}, omitEmpty: true,
+			predict:  func(r repr) bool { return r.EncodeWitnessesEmpty },
+			faithful: false, setLit: `c.TagsOE = []string{}`, wireSilent: true,
+		},
+		{
+			// #1/#94: the array-of-tables encoder is entry-driven — empty is
+			// silent and collapses to nil (decode DOES read `= []`; see the
+			// decode-side cells below — the asymmetry is encode-only).
+			name: "empty-slice-struct", shape: spkSlice{Elem: serverT},
+			predict:  func(r repr) bool { return r.EncodeWitnessesEmpty },
+			faithful: false, setLit: `c.Servers = []Server{}`, wireSilent: true,
+		},
+		{
+			// map[string]scalar witnesses present-empty with its bare [table].
+			name: "empty-map-scalar", shape: spkMap{Elem: stringT},
+			predict:  func(r repr) bool { return r.EncodeWitnessesEmpty },
+			faithful: true, setLit: `c.Mc = map[string]string{}`, wantLit: `Config{Mc: map[string]string{}}`, wire: "[mc]",
+		},
+		{
+			// omitempty is a LEAF-only option: ceMapScalar never carries it
+			// (comp_build threads OmitEmpty into ceLeaf only), so an omitempty
+			// scalar map still witnesses present-empty.
+			name: "empty-map-scalar-omitempty-ignored", shape: spkMap{Elem: stringT}, omitEmpty: true,
+			predict:  func(r repr) bool { return r.EncodeWitnessesEmpty },
+			faithful: true, setLit: `c.McOE = map[string]string{}`, wantLit: `Config{McOE: map[string]string{}}`, wire: "[mc_oe]",
+		},
+		{
+			// map[string]struct is entry-driven: empty is silent → nil.
+			name: "empty-map-struct", shape: spkMap{Elem: serverT},
+			predict:  func(r repr) bool { return r.EncodeWitnessesEmpty },
+			faithful: false, setLit: `c.MS = map[string]Server{}`, wireSilent: true,
+		},
+		{
+			// map[string]NamedMap likewise (compEncMapMap gates on len > 0).
+			name: "empty-mapmap", shape: spkMap{Elem: spkMap{Elem: stringT}},
+			predict:  func(r repr) bool { return r.EncodeWitnessesEmpty },
+			faithful: false, setLit: `c.MM = map[string]Named{}`, wireSilent: true,
+		},
+		{
+			// A pointer struct with a non-array-table body always witnesses via
+			// its [table] header: &Wrapper{nil} round-trips. (This cell disproved
+			// the first prototype's AND-over-fields silence rule.)
+			name: "ptr-struct-header-witnesses", shape: spkPtr{Elem: spkStruct{TypeName: "Wrapper", InnerInfo: wrapper}},
+			predict:  func(r repr) bool { return r.FullyFaithful },
+			faithful: true, setLit: `c.W = &Wrapper{}`, wantLit: `Config{W: &Wrapper{}}`, wire: "[w]",
+		},
+		{
+			// #122: all fields array-tables → #89 skips the header → a non-nil
+			// pointer with an all-silent body collapses to nil.
+			name: "ptr-all-array-tables-silent", shape: spkPtr{Elem: spkStruct{TypeName: "AllTables", InnerInfo: allTables}},
+			predict:  func(r repr) bool { return r.SilentFaithful },
+			faithful: false, setLit: `c.AT = &AllTables{}`, wireSilent: true,
+		},
+	}
+
+	// Model ↔ empirical-table agreement, before compiling anything: a model
+	// change that flips a cell's prediction fails here with the cell named.
+	for _, c := range cells {
+		r := reprOf(c.shape, c.omitEmpty, false)
+		if got := c.predict(r); got != c.faithful {
+			t.Fatalf("model drift on cell %q: fold predicts %v, empirical truth is %v (repr=%+v)",
+				c.name, got, c.faithful, r)
+		}
+	}
+
+	// Generate the fixture package and assert each cell against reality.
+	dir := t.TempDir()
+	repoRoot, err := filepath.Abs(filepath.Join("..", "."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFixture(t, dir, "go.mod", strings.Join([]string{
+		"module example.com/reprconf", "", "go 1.26", "",
+		"require github.com/amarbel-llc/tommy v0.0.0", "",
+		"replace github.com/amarbel-llc/tommy => " + repoRoot, "",
+	}, "\n"))
+	writeFixture(t, dir, "config.go", reprConfFixtureSrc)
+
+	if err := Generate(dir, "config.go"); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var body strings.Builder
+	for _, c := range cells {
+		expectLit := c.wantLit
+		if !c.faithful {
+			// A lossy cell collapses to the absent default — the zero Config.
+			expectLit = "Config{}"
+		}
+		var wireCheck string
+		switch {
+		case c.wireSilent:
+			wireCheck = `	if len(out) != 0 { t.Fatalf("expected a silent encode, got:\n%s", out) }` + "\n"
+		case c.wire != "":
+			wireCheck = fmt.Sprintf(`	if !strings.Contains(string(out), %q) { t.Fatalf("missing witness %%q in:\n%%s", %q, out) }`+"\n", c.wire, c.wire)
+		}
+		fmt.Fprintf(&body, `	t.Run(%q, func(t *testing.T) {
+	d, err := DecodeConfig([]byte(""))
+	if err != nil { t.Fatal(err) }
+	c := d.Data()
+	%s
+	out, err := d.Encode()
+	if err != nil { t.Fatalf("encode: %%v", err) }
+%s	d2, err := DecodeConfig(out)
+	if err != nil { t.Fatalf("re-decode: %%v\ntoml:\n%%s", err, out) }
+	expect := %s
+	if !reflect.DeepEqual(*d2.Data(), expect) {
+		t.Fatalf("cell outcome changed\nexpect: %%s\ngot:    %%s\ntoml:\n%%s", dump(expect), dump(*d2.Data()), out)
+	}
+	})
+`, c.name, c.setLit, wireCheck, expectLit)
+	}
+
+	// Cells the per-field repr table doesn't express:
+	body.WriteString(reprConfExtraCells)
+
+	testSrc := "package reprconf\n\nimport (\n\t\"fmt\"\n\t\"reflect\"\n\t\"sort\"\n\t\"strings\"\n\t\"testing\"\n)\n\n" +
+		"func ptr[T any](v T) *T { return &v }\n\n" + dumpHelperSrc +
+		"func TestConformance(t *testing.T) {\n" + body.String() + "}\n"
+	writeFixture(t, dir, "conformance_test.go", testSrc)
+
+	cmd := exec.Command("go", "test", "-count=1", "./...")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), testGoEnv()...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("conformance failed:\n%s\n--- conformance_test.go ---\n%s", out, testSrc)
+	}
+}
+
+const reprConfFixtureSrc = `package reprconf
+
+//go:generate tommy generate
+type Config struct {
+	B       bool               ` + "`toml:\"b\"`" + `
+	PB      *bool              ` + "`toml:\"pb\"`" + `
+	Tags    []string           ` + "`toml:\"tags\"`" + `
+	TagsOE  []string           ` + "`toml:\"tags_oe,omitempty\"`" + `
+	Servers []Server           ` + "`toml:\"servers\"`" + `
+	PServers []*Server         ` + "`toml:\"pservers\"`" + `
+	Mc      map[string]string  ` + "`toml:\"mc\"`" + `
+	McOE    map[string]string  ` + "`toml:\"mc_oe,omitempty\"`" + `
+	MS      map[string]Server  ` + "`toml:\"ms\"`" + `
+	MSP     map[string]*Server ` + "`toml:\"msp\"`" + `
+	MM      map[string]Named   ` + "`toml:\"mm\"`" + `
+	W       *Wrapper           ` + "`toml:\"w\"`" + `
+	AT      *AllTables         ` + "`toml:\"at\"`" + `
+}
+
+type Named map[string]string
+
+type Server struct {
+	Host string ` + "`toml:\"host\"`" + `
+}
+
+type Wrapper struct {
+	S *Server ` + "`toml:\"s\"`" + `
+}
+
+type AllTables struct {
+	Xs []Server ` + "`toml:\"xs\"`" + `
+}
+`
+
+// reprConfExtraCells covers behavior outside the per-field repr table:
+// decode-side present-empty reading (the asymmetry's other half) and the
+// nil-element policies (TOML has no null; encode must not panic).
+const reprConfExtraCells = `	t.Run("decode-reads-empty-array-of-tables", func(t *testing.T) {
+	// DecodeReadsEmpty: the decoder maps servers = [] to a NON-nil empty
+	// slice — only the encoder lacks the present-empty witness.
+	d, err := DecodeConfig([]byte("servers = []\n"))
+	if err != nil { t.Fatal(err) }
+	if d.Data().Servers == nil || len(d.Data().Servers) != 0 {
+		t.Fatalf("expected non-nil empty, got %s", dump(d.Data().Servers))
+	}
+	})
+	t.Run("decode-reads-empty-map-struct-table", func(t *testing.T) {
+	d, err := DecodeConfig([]byte("[ms]\n"))
+	if err != nil { t.Fatal(err) }
+	if d.Data().MS == nil || len(d.Data().MS) != 0 {
+		t.Fatalf("expected non-nil empty, got %s", dump(d.Data().MS))
+	}
+	})
+	t.Run("nil-slice-element-skipped", func(t *testing.T) {
+	// A nil []*Struct element has no TOML representation: encode skips it
+	// (and must not panic — it dereferenced nil before 2026-06-09).
+	d, err := DecodeConfig([]byte(""))
+	if err != nil { t.Fatal(err) }
+	d.Data().PServers = []*Server{nil, {Host: "h"}}
+	out, err := d.Encode()
+	if err != nil { t.Fatalf("encode: %v", err) }
+	d2, err := DecodeConfig(out)
+	if err != nil { t.Fatalf("re-decode: %v\ntoml:\n%s", err, out) }
+	expect := []*Server{{Host: "h"}}
+	if !reflect.DeepEqual(d2.Data().PServers, expect) {
+		t.Fatalf("expect %s got %s\ntoml:\n%s", dump(expect), dump(d2.Data().PServers), out)
+	}
+	})
+	t.Run("nil-map-element-becomes-empty-entry", func(t *testing.T) {
+	// The map encoder creates the [msp.k] sub-table BEFORE its nil check, so a
+	// nil entry round-trips as a non-nil empty struct rather than dropping —
+	// pinned here as the (inconsistent with slices) current policy.
+	d, err := DecodeConfig([]byte(""))
+	if err != nil { t.Fatal(err) }
+	d.Data().MSP = map[string]*Server{"k": nil}
+	out, err := d.Encode()
+	if err != nil { t.Fatalf("encode: %v", err) }
+	d2, err := DecodeConfig(out)
+	if err != nil { t.Fatalf("re-decode: %v\ntoml:\n%s", err, out) }
+	expect := map[string]*Server{"k": {}}
+	if !reflect.DeepEqual(d2.Data().MSP, expect) {
+		t.Fatalf("expect %s got %s\ntoml:\n%s", dump(expect), dump(d2.Data().MSP), out)
+	}
+	})
+`

--- a/generate/representability_test.go
+++ b/generate/representability_test.go
@@ -2,9 +2,10 @@ package generate
 
 import "testing"
 
-// Validates the representability fold (ADR 2026-06-08 prototype) against the four
-// value-space bug cells it must predict. If the static fold matches the bugs we
-// found empirically, the model is a viable single source of truth.
+// Unit cells for the representability fold. Every expectation here is the
+// empirically verified behavior of the generated encoder/decoder pair — the
+// conformance harness (representability_conformance_test.go) asserts the same
+// predictions against compiled generated code, so these stay honest.
 
 func scalar() spkType { return spkScalar{Codec: codecPrim, TypeName: "string"} }
 
@@ -13,64 +14,152 @@ func structOf(fields ...FieldInfo) spkStruct {
 }
 
 func TestReprScalar(t *testing.T) {
-	if reprOf(scalar(), false).MayBeSilent {
-		t.Error("a non-omitempty scalar always emits — must not be silent")
+	r := reprOf(scalar(), false, false)
+	if !r.MayBeSilent {
+		t.Error("a non-omitempty zero scalar is suppressed when absent from the document — silent")
 	}
-	if !reprOf(scalar(), true).MayBeSilent {
-		t.Error("an omitempty scalar omits its zero value — must be silent")
+	if !r.SilentFaithful || !r.FullyFaithful {
+		t.Error("the silent value IS the decode-absent zero — silence is faithful")
+	}
+	if !reprOf(scalar(), true, false).FullyFaithful {
+		t.Error("an omitempty scalar omits only its zero, which decodes back to zero — faithful")
 	}
 }
 
-// #121 vs #1: a []scalar has a present-empty form (`= []`) so empty is distinct
-// from nil; an array-of-tables ([]struct) has none, so empty collapses to nil.
+func TestReprPtrScalar(t *testing.T) {
+	r := reprOf(spkPtr{Elem: scalar()}, false, false)
+	if !r.MayBeSilent {
+		t.Error("nil pointer is silent")
+	}
+	if !r.SilentFaithful || !r.FullyFaithful {
+		t.Error("a non-nil *scalar always emits, zero included (`pb = false`) — fully faithful")
+	}
+}
+
+// #121 vs #1: a []scalar witnesses present-empty (`= []`); an array-of-tables
+// does not — its encode is entry-driven, so empty collapses to nil even though
+// the DECODER reads an explicit `= []` into a non-nil empty slice.
 func TestReprSliceEmptyForm(t *testing.T) {
-	if !reprOf(spkSlice{Elem: scalar()}, false).EmptyDistinct {
-		t.Error("[]scalar: empty `= []` must be distinct from nil (#121)")
+	r := reprOf(spkSlice{Elem: scalar()}, false, false)
+	if !r.EncodeWitnessesEmpty || !r.FullyFaithful {
+		t.Error("[]scalar: empty `= []` must be witnessed on encode (#121)")
 	}
-	if reprOf(spkSlice{Elem: structOf(FieldInfo{Type: scalar()})}, false).EmptyDistinct {
-		t.Error("[]struct: empty array-of-tables has no present form (#1)")
+	if reprOf(spkSlice{Elem: scalar()}, true, false).FullyFaithful {
+		t.Error("[]scalar omitempty: empty collapses to absent → decodes nil ≠ empty — lossy at empty")
 	}
-	if reprOf(spkSlice{Elem: spkPtr{Elem: structOf(FieldInfo{Type: scalar()})}}, false).EmptyDistinct {
-		t.Error("[]*struct: still an array-of-tables — no present-empty form")
+	for _, c := range []struct {
+		name string
+		t    spkType
+	}{
+		{"[]struct", spkSlice{Elem: structOf(FieldInfo{Type: scalar()})}},
+		{"[]*struct", spkSlice{Elem: spkPtr{Elem: structOf(FieldInfo{Type: scalar()})}}},
+	} {
+		r := reprOf(c.t, false, false)
+		if r.EncodeWitnessesEmpty {
+			t.Errorf("%s: encoder never emits a present-empty array-of-tables (#1)", c.name)
+		}
+		if !r.DecodeReadsEmpty {
+			t.Errorf("%s: decoder DOES read `= []` to a non-nil empty slice — the asymmetry", c.name)
+		}
+		if r.FullyFaithful {
+			t.Errorf("%s: empty collapses to nil — not fully faithful", c.name)
+		}
 	}
 }
 
-// #122: a struct whose only field is an array-of-tables can be all-silent, so a
-// non-nil pointer to it does not round-trip. A struct with a required scalar
-// always witnesses, so a non-nil pointer to it always round-trips.
-func TestReprPointerStructRoundTrips(t *testing.T) {
-	// Sub7 { F0 []*Sub8 } — the exact #122 shape.
-	sub7 := &StructInfo{Name: "Sub7", Fields: []FieldInfo{
-		{GoName: "F0", TomlKey: "f0", Type: spkSlice{Elem: spkPtr{Elem: structOf(FieldInfo{Type: scalar()})}}},
-	}}
-	if pointerStructRoundTrips(sub7) {
-		t.Error("*Sub7{F0:nil} is silent → must be flagged as NOT round-tripping (#122)")
+func TestReprMapEmptyForm(t *testing.T) {
+	if r := reprOf(spkMap{Elem: scalar()}, false, false); !r.EncodeWitnessesEmpty || !r.FullyFaithful {
+		t.Error("map[string]scalar: empty emits its bare [table] header — fully faithful")
 	}
+	for _, c := range []struct {
+		name string
+		t    spkType
+	}{
+		{"map[string]struct", spkMap{Elem: structOf(FieldInfo{Type: scalar()})}},
+		{"map[string]NamedMap", spkMap{Elem: spkMap{Elem: scalar()}}},
+	} {
+		r := reprOf(c.t, false, false)
+		if r.EncodeWitnessesEmpty || r.FullyFaithful {
+			t.Errorf("%s: entry-driven encode gives empty no witness — lossy at empty", c.name)
+		}
+		if !r.DecodeReadsEmpty {
+			t.Errorf("%s: decoder materializes a non-nil map from a bare [table]", c.name)
+		}
+	}
+}
 
-	// Server { Host string } — a required scalar always witnesses.
+// The struct witness rule. The first prototype computed silence as AND over
+// fields; the conformance harness disproved that: a struct witnesses via its
+// own [table] header regardless of its body — EXCEPT when every field is an
+// array-of-tables, where #89 skips the header (the #122 cell).
+func TestReprStructWitness(t *testing.T) {
 	server := &StructInfo{Name: "Server", Fields: []FieldInfo{
 		{GoName: "Host", TomlKey: "host", Type: scalar()},
 	}}
-	if !pointerStructRoundTrips(server) {
-		t.Error("*Server always witnesses via Host → must round-trip")
-	}
 
-	// A struct of only optional/collection fields is silent-able.
-	loose := &StructInfo{Name: "Loose", Fields: []FieldInfo{
-		{GoName: "A", TomlKey: "a", Type: scalar(), OmitEmpty: true},
-		{GoName: "B", TomlKey: "b", Type: spkSlice{Elem: scalar()}},
-		{GoName: "C", TomlKey: "c", Type: spkPtr{Elem: scalar()}},
-	}}
-	if pointerStructRoundTrips(loose) {
-		t.Error("a struct of only omitempty/slice/pointer fields can be all-silent")
-	}
-
-	// Nesting: a struct whose only field is a *Server (silent when nil) is itself
-	// silent-able, even though Server alone always witnesses.
+	// Wrapper{S *Server}: nil-able body, but the [w] header always witnesses —
+	// &Wrapper{nil} round-trips (verified by the wrapper-nil-inner cell).
 	wrapper := &StructInfo{Name: "Wrapper", Fields: []FieldInfo{
 		{GoName: "S", TomlKey: "s", Type: spkPtr{Elem: spkStruct{TypeName: "Server", InnerInfo: server}}},
 	}}
-	if pointerStructRoundTrips(wrapper) {
-		t.Error("Wrapper{*Server} is silent when S is nil → must not be claimed round-tripping")
+	if structHeaderSkipped(wrapper, false) {
+		t.Error("Wrapper{*Server}: not all-array-tables — header emitted")
+	}
+	if r := reprOf(spkPtr{Elem: spkStruct{TypeName: "Wrapper", InnerInfo: wrapper}}, false, false); !r.FullyFaithful {
+		t.Error("&Wrapper{nil} witnesses via [w] and round-trips — fully faithful")
+	}
+
+	// AllTables{Xs []Server} — the #122 shape: all fields are array-tables, the
+	// header is skipped, and a non-nil pointer with a nil/empty body is silent.
+	allTables := &StructInfo{Name: "AllTables", Fields: []FieldInfo{
+		{GoName: "Xs", TomlKey: "xs", Type: spkSlice{Elem: spkStruct{TypeName: "Server", InnerInfo: server}}},
+	}}
+	if !structHeaderSkipped(allTables, false) {
+		t.Error("AllTables: every field an array-of-tables — #89 skips the header")
+	}
+	r := reprOf(spkPtr{Elem: spkStruct{TypeName: "AllTables", InnerInfo: allTables}}, false, false)
+	if !r.MayBeSilent || r.SilentFaithful || r.FullyFaithful {
+		t.Error("&AllTables{} is silent and ≠ nil — the #122 lossy cell")
+	}
+
+	// The same shape inside an array-table entry is scoped: the entry header
+	// witnesses, so the table header is kept and the cell disappears.
+	if structHeaderSkipped(allTables, true) {
+		t.Error("scoped AllTables keeps its header — the #122 cell is positional")
+	}
+
+	// A value-struct AllTables field is silent-able but FAITHFUL: the silent
+	// body is all absent-defaults, exactly what decode-absent produces. Its
+	// unfaithfulness comes only from the child cells (empty []struct).
+	rv := reprOf(spkStruct{TypeName: "AllTables", InnerInfo: allTables}, false, false)
+	if !rv.MayBeSilent || !rv.SilentFaithful {
+		t.Error("value AllTables: silent body == zero value — faithful in itself")
+	}
+	if rv.FullyFaithful {
+		t.Error("value AllTables: still not FULLY faithful — its []struct child loses empty")
+	}
+}
+
+// Faithfulness composes through nesting: one lossy child poisons the struct.
+func TestReprStructComposition(t *testing.T) {
+	server := &StructInfo{Name: "Server", Fields: []FieldInfo{
+		{GoName: "Host", TomlKey: "host", Type: scalar()},
+	}}
+	clean := &StructInfo{Name: "Clean", Fields: []FieldInfo{
+		{GoName: "A", TomlKey: "a", Type: scalar()},
+		{GoName: "B", TomlKey: "b", Type: spkSlice{Elem: scalar()}},
+		{GoName: "C", TomlKey: "c", Type: spkPtr{Elem: spkStruct{TypeName: "Server", InnerInfo: server}}},
+		{GoName: "D", TomlKey: "d", Type: spkMap{Elem: scalar()}},
+	}}
+	if !structFullyFaithful(clean, false) {
+		t.Error("scalars, []scalar, *struct-with-header, map[string]scalar: all faithful")
+	}
+
+	dirty := &StructInfo{Name: "Dirty", Fields: []FieldInfo{
+		{GoName: "A", TomlKey: "a", Type: scalar()},
+		{GoName: "Xs", TomlKey: "xs", Type: spkSlice{Elem: spkStruct{TypeName: "Server", InnerInfo: server}}},
+	}}
+	if structFullyFaithful(dirty, false) {
+		t.Error("one []struct field (lossy at empty) must poison the struct")
 	}
 }

--- a/generate/roundtrip_gen_test.go
+++ b/generate/roundtrip_gen_test.go
@@ -323,27 +323,82 @@ func (g *shapeGen) goTypeIn(t *td, cur string) string {
 	panic("bad td kind: " + t.kind)
 }
 
+// tdToSpk maps the fuzzer's td shape onto the TypeExpr algebra so the value
+// generator can ask the representability fold (representability.go) which
+// nil/empty variants round-trip, instead of hand-maintaining a parallel copy
+// of the encoder's value-space rules (the ADR 2026-06-08 "fifth sync site").
+func tdToSpk(t *td) spkType {
+	switch t.kind {
+	case "scalar":
+		return spkScalar{Codec: codecPrim, TypeName: t.scalar}
+	case "text":
+		return spkScalar{Codec: codecText, TypeName: t.stName}
+	case "ptr":
+		return spkPtr{Elem: tdToSpk(t.elem)}
+	case "slice":
+		return spkSlice{Elem: tdToSpk(t.elem)}
+	case "map":
+		return spkMap{Elem: tdToSpk(t.elem)}
+	case "mapmap":
+		return spkMap{Elem: spkMap{Elem: spkScalar{Codec: codecPrim, TypeName: "string"}}}
+	case "namedmapstruct":
+		return spkMap{Elem: tdToSpk(t.elem)}
+	case "struct":
+		si := &StructInfo{Name: t.stName}
+		for _, f := range t.fields {
+			si.Fields = append(si.Fields, FieldInfo{GoName: f.name, TomlKey: f.tomlKey, Type: tdToSpk(f.t), OmitEmpty: f.omitEmpty})
+		}
+		if t.pkg != "" {
+			// Cross-package: a delegated leaf (its encoder always emits the
+			// table header, unlike a same-package #89-skippable struct).
+			return spkDelegated{TypeName: t.pkg + "." + t.stName, InnerInfo: si}
+		}
+		return spkStruct{TypeName: t.stName, InnerInfo: si}
+	}
+	panic("bad td kind: " + t.kind)
+}
+
+// tdNilable reports whether a FIELD of this shape may be generated nil: every
+// reference kind is, since an absent key decodes back to nil. (Slice/map
+// ELEMENTS are never generated nil — TOML has no null — which genValue
+// guarantees structurally: nil injection happens only in the struct-field loop.)
+func tdNilable(t *td) bool {
+	switch t.kind {
+	case "ptr", "slice", "map", "mapmap", "namedmapstruct":
+		return true
+	}
+	return false
+}
+
+// tdIsArrayTable reports whether the field encodes as an array-of-tables.
+func tdIsArrayTable(t *td) bool {
+	return t.kind == "slice" && elemIsStructish(tdToSpk(t.elem))
+}
+
 // genValue emits a Go composite literal populating t. Every slice/map gets two
 // distinct entries so a swapped index or mis-scoped entry is caught by DeepEqual.
 func (g *shapeGen) genValue(t *td) string {
-	// nil/empty generation is confined to representable positions, all injected by
-	// the struct case below (~1/4 each). As a STRUCT FIELD, a nil pointer / nil map
-	// / nil slice round-trips cleanly (the key is simply absent). A present-but-
-	// empty PRIMITIVE slice (`= []`) and an empty map[string]string (an empty
-	// `[table]`) are distinct TOML forms, so both nil AND empty are generated for
-	// them. A map[string]Struct has no present-empty form, so only its nil variant
-	// is generated, never `{}`. An array-of-tables ([]struct / []*struct) generates
-	// NEITHER nil nor empty: a nil one as a struct's only emitting field makes that
-	// struct encode to nothing — unrepresentable behind a pointer (it round-trips
-	// to a nil pointer, cf. #89) — so it stays populated. A nil pointer as a
-	// slice/map ELEMENT is never generated either: TOML arrays/sub-tables have no
-	// null, so []*T{nil} / map[string]*T{k:nil} are unrepresentable.
+	return g.genValueCtx(t, false)
+}
+
+// genValueCtx threads one positional bit: guardAT marks a struct value sitting
+// behind a pointer FIELD whose table header the #89 rule skips (every field an
+// array-of-tables). In that position the struct body is the pointer's only
+// presence witness, so its array-table fields must stay populated — an
+// all-silent body would round-trip the pointer to nil (#122). Everywhere else
+// (top level, value structs, slice/map entries — whose entry headers witness)
+// the nil/empty policy is derived per-field from the representability fold.
+func (g *shapeGen) genValueCtx(t *td, guardAT bool) string {
 	switch t.kind {
 	case "scalar":
 		return g.scalarValue(t.scalar)
 	case "ptr":
 		if t.elem.kind == "struct" {
-			return "&" + g.genValue(t.elem)
+			inner := false
+			if s, ok := tdToSpk(t.elem).(spkStruct); ok {
+				inner = structHeaderSkipped(s.InnerInfo, false)
+			}
+			return "&" + g.genValueCtx(t.elem, inner)
 		}
 		return "ptr(" + g.genValue(t.elem) + ")"
 	case "slice":
@@ -379,57 +434,20 @@ func (g *shapeGen) genValue(t *td) string {
 				b.WriteString(", ")
 			}
 			fv := g.genValue(f.t)
-			// Emit nil/empty variants where they round-trip faithfully (#21). A nil
-			// *scalar / *struct / map / mapmap field is simply an absent key/[table].
-			// A primitive slice distinguishes nil (key omitted) from empty `= []`, so
-			// generate both. An array-table slice ([]struct / []*struct) has no
-			// present-empty TOML form (an array-of-tables exists only with ≥1 entry),
-			// so nil≡empty there — keep those populated. Nil collection ELEMENTS stay
-			// excluded (TOML has no null).
-			// An ,omitempty field omits empty AND nil → both decode nil, so the
-			// empty-collection variant (which would round-trip to nil, not empty) is
-			// suppressed for omitempty fields; nil and populated still round-trip.
-			switch f.t.kind {
-			case "mapmap", "ptr", "namedmapstruct":
-				// namedmapstruct is a map[string]struct alias — no present-empty
-				// form (like map[string]Struct), so nil-only, never `{}`.
-				if g.rng.Intn(4) == 0 {
-					fv = "nil"
-				}
-			case "map":
-				// map[string]string (scalar elem) has a present-empty form (an empty
-				// `[table]`), so it's faithful: generate nil AND empty. map[string]Struct
-				// uses `[m.key]` sub-tables with no distinct empty representation, so it
-				// normalizes nil≡empty — only nil there.
-				if f.t.elem.kind == "scalar" {
-					switch r := g.rng.Intn(4); {
-					case r == 0:
-						fv = "nil"
-					case r == 1 && !f.omitEmpty:
-						fv = g.goType(f.t) + "{}"
-					}
-				} else if g.rng.Intn(4) == 0 {
-					fv = "nil"
-				}
-			case "slice":
-				primElem := f.t.elem.kind == "scalar" ||
-					(f.t.elem.kind == "ptr" && f.t.elem.elem.kind == "scalar")
-				if primElem {
-					// A primitive slice distinguishes nil (key omitted) from empty
-					// (`= []`) — exercise both.
-					switch r := g.rng.Intn(4); {
-					case r == 0:
-						fv = "nil"
-					case r == 1 && !f.omitEmpty:
-						fv = g.goType(f.t) + "{}"
-					}
-				}
-				// An array-of-tables ([]struct / []*struct) stays populated: it has
-				// no present-empty TOML form, and a nil one that is a struct's only
-				// emitting field makes that struct encode to nothing — which is
-				// unrepresentable behind a pointer (it round-trips to a nil pointer,
-				// cf. #89's no-spurious-bare-section rule). So neither nil nor empty
-				// is generated for it.
+			// The nil/empty policy is DERIVED from the representability fold
+			// rather than hand-coded per kind (~1/4 nil, ~1/4 empty where each
+			// round-trips): nil is faithful for every reference field (absent →
+			// nil), except an array-table field under guardAT (see genValueCtx);
+			// present-empty is generated exactly where the encoder witnesses it
+			// (EncodeWitnessesEmpty — `= []` / a bare `[table]`, minus omitempty
+			// leaves, which collapse empty to absent).
+			r := reprOf(tdToSpk(f.t), f.omitEmpty, false)
+			nilOK := tdNilable(f.t) && !(guardAT && tdIsArrayTable(f.t))
+			switch p := g.rng.Intn(4); {
+			case p == 0 && nilOK:
+				fv = "nil"
+			case p == 1 && r.EncodeWitnessesEmpty:
+				fv = g.goType(f.t) + "{}"
 			}
 			b.WriteString(f.name + ": " + fv)
 		}


### PR DESCRIPTION
Two live bugs surfaced by empirically probing the representability
boundary cells (ADR 2026-06-08):

- Encoding a []*Struct (same-package or delegated) containing a nil
  element dereferenced it and panicked. Nil elements are now skipped,
  the policy compEncMapStruct and compSlicePrimSet already apply (TOML
  has no null).
- The generated entry-handle types were named after the element struct
  (serverHandle), a file-scoped declaration: two slice fields sharing an
  element type — or two directive structs with same-named fields — broke
  the build with a redeclaration. Handles are now named struct+field
  (configServersHandle) via handleTypeName, threaded through the decode
  fold as cdArrayTable.HandleType.

https://claude.ai/code/session_017gZ28j38vuPePSmc6qVkD2